### PR TITLE
Allows Instructors to Change Current and Default Zoom Links

### DIFF
--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -10,6 +10,13 @@ app.config.from_pyfile('config.cfg')
 app.jinja_env.auto_reload = True
 
 db = SQLAlchemy(app)
+
+# Use this to add the ZoomLinks tabs to the databse
+
+# from helphours.models.zoom_link import ZoomLink
+# db.create_all()
+# db.session.commit()
+
 login = LoginManager(app)
 
 notifier = Notifier(app.config['EMAIL_ACCOUNT'],

--- a/helphours/models/zoom_link.py
+++ b/helphours/models/zoom_link.py
@@ -5,4 +5,4 @@ class ZoomLink(db.Model):
     __tablename__ = "zoomlinks"
     id = db.Column(db.Integer, primary_key=True)
     url = db.Column(db.String(128))
-    description = db.Column(db.String(256))
+    description = db.Column(db.String(512))

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -135,7 +135,7 @@ def change_zoom():
             if validators.url(temp):
                 current_zoom_link = temp
                 message = "The link has been changed"
-                log.info(f'{current_user.first_name} {current_user.last_name} channged the zoom link to a custom link.')
+                log.info(f'{current_user.first_name} {current_user.last_name} changed the zoom link to a custom link.')
             else:
                 message = "Invalid URL"
     return render_template('change_zoom.html', message=message, preset_links=preset_links)

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -16,6 +16,7 @@ from werkzeug.security import generate_password_hash
 queue_is_open = False
 current_zoom_link = ''
 
+
 @app.before_request
 def inject_variables():
     g.user = current_user
@@ -112,7 +113,6 @@ def zoom_redirect():
 def change_zoom():
     global current_zoom_link
     preset_links = ZoomLink.query.all()
-    # preset_links = []
     message = ""
 
     if request.method == 'POST':

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -121,8 +121,28 @@ body h3 {
     padding: 10px 0;
 }
 
+textarea {
+ margin: 10px 0px;   
+ width: 100%;
+}
+
 .error-message {
     color: red;
+}
+
+.form-group {
+    margin: 20px 0;
+}
+
+.select-menu {
+    /* margin: 10px; */
+    margin: 10px 0;
+    width: 100%;
+}
+
+.url-input {
+    margin: 10px 0;
+    width: 100%;
 }
 
 .queue-container {

--- a/helphours/templates/admin_panel.html
+++ b/helphours/templates/admin_panel.html
@@ -31,16 +31,16 @@
                         </td>
                         <td>
                             {% if instructor.is_active %}
-                            Active
+                                Active
                             {% else %}
-                            Inactive
+                                Inactive
                             {% endif %}
                         </td>
                         <td>
                             {% if instructor.is_admin %}
-                            Admin
+                                Admin
                             {% else %}
-                            -
+                                -
                             {% endif %}
                         </td>
                         <td>

--- a/helphours/templates/base.html
+++ b/helphours/templates/base.html
@@ -7,28 +7,52 @@
 
     <body>
 
-        <div class="navbar">
+        <nav class="navbar">
             <ul aria-label="Navigation menu" class="left-links">
-                <li><a class="link" href="{{ url_for('index') }}">Home</a></li>
-                <li><a class="link" href="{{ url_for('join') }}">Join</a></li>
-                <li><a class="link" href="{{ url_for('view') }}">View</a></li>
-                <li><a class="link" href="{{ url_for('remove') }}">Remove self</a></li>
-                <li><a class="link" href="{{ url_for('zoom_redirect') }}" target="_blank">Zoom Meeting</a></li>
-                <li><a class="link" href="{{ url_for('schedule_redirect') }}" target="_blank">Schedule</a></li>
+                <li {% if request.path == url_for('index') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('index') }}">Home</a>
+                </li>
+                <li {% if request.path == url_for('join') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('join') }}">Join</a>
+                </li>
+                <li {% if request.path == url_for('view') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('view') }}">View</a>
+                </li>
+                <li {% if request.path == url_for('remove') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('remove') }}">Remove self</a>
+                </li>
+                <li {% if request.path == url_for('zoom_redirect') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('zoom_redirect') }}" target="_blank">Zoom Meeting</a>
+                </li>
+                <li {% if request.path == url_for('schedule_redirect') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('schedule_redirect') }}" target="_blank">Schedule</a>
+                </li>
             </ul>
             <ul class="right-links">
                 {% if g.user.is_authenticated %}
-                <li><a class="link" href="{{ url_for('stats_page') }}">Stats</a></li>
+                    <li {% if request.path == url_for('change_zoom') %} class="active" {% endif %}>
+                        <a class="link" href="{{ url_for('change_zoom') }}">Change Zoom Link</a>
+                    </li>
+                    <li {% if request.path == url_for('stats_page') %} class="active" {% endif %}>
+                        <a class="link" href="{{ url_for('stats_page') }}">Stats</a>
+                    </li>
                     {% if g.user.is_admin %}
-                        <li><a class="link" href="{{ url_for('admin_panel') }}">Admin</a></li>
+                        <li {% if request.path == url_for('admin_panel') %} class="active" {% endif %}>
+                            <a class="link" href="{{ url_for('admin_panel') }}">Admin</a>
+                        </li>
                     {% endif %}
-                <li><a class="link" href="{{ url_for('logout') }}">Logout</a></li>
+
+                <li {% if request.path == url_for('logout') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('logout') }}">Logout</a>
+                </li>
                 {% else %}
-                <li><a class="link" href="{{ url_for('login') }}">Instructor Login</a></li>
+                <li {% if request.path == url_for('login') %} class="active" {% endif %}>
+                    <a class="link" href="{{ url_for('login') }}">Instructor Login</a>
+                </li>
                 {% endif %}
 
             </ul>
-        </div>
+        </nav>
         <div class="content">
             {% block body %}
             {% endblock %}

--- a/helphours/templates/change_zoom.html
+++ b/helphours/templates/change_zoom.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block head %}
+<title>Change Zoom Link</title>
+{% endblock %}
+
+{% block body %}
+
+<div class="center-content">
+    <div class="form-container">
+        <h2 class="form-title">Change Zoom Link</h2>
+        <form class="form" method="POST">
+            
+            {% if message|length > 0 %}
+                <p class="error-message">{{ message }}</p>
+            {% endif %}
+
+            <div class="form-group">
+            <h3> Choose a Preset Link </h3>
+                <select name="preset-links" class="select-menu">
+                    <option value=0>Choose Link</option>
+                    {% for i in range(preset_links | length) %}
+                        <option value={{ i+1 }}>{{ preset_links[i].description }}</option>
+                    {% endfor %}
+                </select>
+                <div class="form-buttons">
+                    <button type="submit" class="form-submit" name="preset">Submit Present Link</button>
+                    <a href="{{ url_for('edit_preset_links') }}">Edit Preset Links</a>
+                </div>
+            </div>
+
+            <div class="center-content">
+                - OR -
+            </div>
+
+            <div class="form-group">
+                <h3> Submit a Different Link </h3>
+                <input class="url-input" name="other-link">
+                <button type="submit" class="form-submit" name="new">Submit New Link</button>
+            </div>
+        </form>
+
+        <br />
+        <br />
+
+    </div>
+</div>
+
+{% endblock %}

--- a/helphours/templates/edit_preset_links.html
+++ b/helphours/templates/edit_preset_links.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block head %}
+<title> Edit Preset Links</title>
+{% endblock %}
+
+{% block body %}
+<div class="center-content">
+    <div class="form-container">
+        <h2 class="form-title">Change Preset Links</h2>
+
+        <form class="form" method="POST">
+            {% if message|length > 0 %}
+                <p class="error-message">{{ message }}</p>
+            {% endif %}
+            <textarea rows='12' name="preset-links" 
+                placeholder="{{'Description 1\nURL 1\n\nDescription 2\nURL 2'}}"
+            >{% for preset in preset_links %}{{ preset.description + '\n' + preset.url + '\n\n'}}{% endfor %}</textarea>
+            <button type="submit" class="form-submit">Update Preset Links</button>
+            <button name="cancel">Cancel</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/helphours/zoom_helper.py
+++ b/helphours/zoom_helper.py
@@ -1,0 +1,31 @@
+import validators
+from helphours.models.zoom_link import ZoomLink
+
+
+class LinkParseError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+def parse_links(raw_text):
+    lines = [line.strip() for line in raw_text.splitlines()]
+    zoom_links = []
+    index = 0
+    temp_description = ""
+    for line in lines:
+        if line:
+            if index % 2 == 0:
+                if len(line) > 256:
+                    raise LinkParseError('Description too long: must be under 512 characters')
+                temp_description = line
+            else:
+                url = line
+                if not validators.url(url):
+                    raise LinkParseError(f'Invalid url: {url}')
+                new_link = ZoomLink(url=url, description=temp_description)
+                zoom_links.append(new_link)
+                temp_description = ''
+            index += 1
+    if index % 2 != 0:
+        raise LinkParseError('Invalid input. There should be 1 description for every url')
+    return zoom_links


### PR DESCRIPTION
Allows instructors to change the current Zoom link (like we had in V2) and also change which default links appear in the dropdown.

These links are stored in the database in a new table called `zoom_links`.

The UI isn't pretty yet, but that'll be fixed when we improve the styles across the page.

Changing the current zoom link:
![changeLink](https://user-images.githubusercontent.com/24216390/90590539-10227f00-e19e-11ea-82fa-508a1522c97f.png)

Changing the default zoom links:
![changePresets](https://user-images.githubusercontent.com/24216390/90590561-22042200-e19e-11ea-985a-d0ab5c48b438.png)
I used a simple `textarea` as the UI for changing the zoom links. It's not the prettiest or cleanest thing in the world, but it seemed like an easy way to provide adding, removing, and re-ordering links and their description without too much effort.
If the text the instructor inputs in the field is found to be invalid, an error message is displayed to them.

The UI is not necessarily final, if you think anything looks weird, let me know.
