### PR TITLE
Fixes the Misleading "Cancel" button in Edit Instructor

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -133,6 +133,9 @@ def edit_instructor():
                                    title="Edit Instructor",
                                    form=form, message='', id=instr.id)
         else:
+            if 'cancel' in request.form:
+                return redirect('admin_panel')
+
             form = InstructorForm()
             if form.validate_on_submit():
                 instr.first_name = form.first_name.data


### PR DESCRIPTION
Fixes the broken 'cancel' button in the Edit Instructor view which actually just acts as a 'Submit' button.

There was no check to see if 'cancel' was present in the form, whoops.

Fixes #19 