### PR TITLE
Fixed renamed config variable bug

### DIFF
--- a/helphours/password_reset.py
+++ b/helphours/password_reset.py
@@ -14,7 +14,7 @@ def create_reset_request(user):
     token = secrets.token_urlsafe(20)
     while token in reset_requests.keys():
         token = secrets.token_urlsafe(20)
-    reset_link = app.config["FULL_URL"] + url_for('reset_password', token=token)
+    reset_link = app.config["WEBSITE_LINK"] + url_for('reset_password', token=token)
     notifier.send_message(user.email, "Lab Hours Password Reset",
                           render_template('emaill/reset_password_email.html', reset_link=reset_link),
                           'html')
@@ -27,7 +27,7 @@ def new_user(user):
     token = secrets.token_urlsafe(20)
     while token in reset_requests.keys():
         token = secrets.token_urlsafe(20)
-    reset_link = app.config["FULL_URL"] + url_for('reset_password', token=token)
+    reset_link = app.config["WESBITE_LINK"] + url_for('reset_password', token=token)
     notifier.send_message(user.email, "New Lab Hours Instructor Account",
                           render_template('email/new_user_email.html', reset_link=reset_link),
                           'html')


### PR DESCRIPTION
In V2, we had a config variable named `FULL_URL`.
It was changed to `WEBSITE_LINK` in most places except a few. This fixes that.