### PR TITLE
Added "/line" route

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -75,6 +75,11 @@ def view():
     return render_template('view.html', queue=queue, queue_is_open=queue_is_open)
 
 
+@app.route("/line", methods=['GET', 'POST'])
+def line():
+    return redirect(url_for('view'))
+
+
 @app.route("/remove", methods=['GET', 'POST'])
 def remove():
     form = RemoveSelfForm()


### PR DESCRIPTION
As Tony found in the logs, we're getting some 404 errors when people are trying to connect to the `/line` route.
This was the route we used in V2 of the app, so perhaps some people set up a bookmark at that route.

The `/line` route was renamed to `/view` in this version, to make the purposes of the `view` and `queue` routes clearer.

To keep those bookmarks working, this commit adds the `/line` route back, redirecting users to `/view` instead.