### PR TITLE
Site now serves a robots.txt for search engine crawlers

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -2,7 +2,7 @@ import json
 import secrets
 import validators
 from helphours import app, log, db, notifier, queue_handler, routes_helper, password_reset, stats, zoom_helper
-from flask import render_template, url_for, redirect, request, g
+from flask import render_template, url_for, redirect, request, g, send_from_directory
 from helphours.forms import JoinQueueForm, RemoveSelfForm, InstructorForm
 from helphours.student import Student
 from flask_login import current_user, login_required
@@ -305,6 +305,9 @@ def close():
     log.info('Queue was closed through /close route')
     return json.dumps({'success': True}), 200, {'ContentType': 'application/json'}
 
+@app.route('/robots.txt')
+def robots_txt():
+    return send_from_directory(app.static_folder, request.path[1:])
 
 # noqa: F401 == Ignore rule about unused imports
 from helphours import error_routes  # noqa: F401

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -305,9 +305,11 @@ def close():
     log.info('Queue was closed through /close route')
     return json.dumps({'success': True}), 200, {'ContentType': 'application/json'}
 
+
 @app.route('/robots.txt')
 def robots_txt():
     return send_from_directory(app.static_folder, request.path[1:])
+
 
 # noqa: F401 == Ignore rule about unused imports
 from helphours import error_routes  # noqa: F401

--- a/helphours/static/robots.txt
+++ b/helphours/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /static/


### PR DESCRIPTION
The newly created robots.txt is configured to prevent search engine crawlers such as Googlebot or Googlebot-Image from crawling our static content, because we most likely don't want our content ending up on Google Images for example.