### PR TITLE
Fixes an inconsistency between hyperlinks

### DIFF
--- a/helphours/templates/about.html
+++ b/helphours/templates/about.html
@@ -61,7 +61,7 @@
     to explain what your code does, line by line, to a rubber duck. Eventually, by explaining it out loud, you'll notice a
     discrepency between what you expect the code does and what it is actually doing. 
   </span>
-  <span>Read more about it <a href="https://en.wikipedia.org/wiki/Rubber_duck_debugging">here!</a></span>
+  <span>Read more about it <a href="https://en.wikipedia.org/wiki/Rubber_duck_debugging">here</a>!</span>
   <p></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
At, the top of the page, where it references "here" for our GitHub, it does not include the punctuation mark.

However, at the bottom, the exclamation mark IS hyperlinked. It is no longer hyperlinked anymore.