### PR TITLE
CircleCI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             - run:
                   name: Running unit tests
                   command: |
+                      set -e
                       . venv/bin/activate
                       mv tests/testing.cfg helphours/config.cfg
                       mv tests/testing.db helphours/helphours.db

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,10 @@ jobs:
                       mv tests/testing.db helphours/helphours.db
                       echo "FLASK_APP=helphours" > .flaskenv
                       cd tests/
-                      chmod 777 run_tests.sh
-                      ./run_tests.sh
+                      echo "running student tests"
+                      python3 student_tests.py
+                      echo "running route tests"
+                      python3 route_tests.py
 
     lint:
         docker:

--- a/tests/route_tests.py
+++ b/tests/route_tests.py
@@ -32,7 +32,7 @@ class TestRoute(unittest.TestCase):
     def test_remove_page(self):
         response = self.app.get('/remove', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-
+    """
     def test_zoom_redirect(self):
         response = self.app.get('/zoom', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
@@ -40,7 +40,7 @@ class TestRoute(unittest.TestCase):
     def test_schedule_redirect(self):
         response = self.app.get('/schedule', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-
+    """
     def test_about_page(self):
         response = self.app.get('/about', follow_redirects=True)
         self.assertEqual(response.status_code, 200)

--- a/tests/route_tests.py
+++ b/tests/route_tests.py
@@ -32,7 +32,7 @@ class TestRoute(unittest.TestCase):
     def test_remove_page(self):
         response = self.app.get('/remove', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-    """
+
     def test_zoom_redirect(self):
         response = self.app.get('/zoom', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
@@ -40,7 +40,7 @@ class TestRoute(unittest.TestCase):
     def test_schedule_redirect(self):
         response = self.app.get('/schedule', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-    """
+
     def test_about_page(self):
         response = self.app.get('/about', follow_redirects=True)
         self.assertEqual(response.status_code, 200)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,0 @@
-for f in *.py
-do
-	echo "running $f"
-	python3 "$f"
-done


### PR DESCRIPTION
Previously, the CircleCI unit tests would pass even if one of our testing scripts ran into an error during testing.

I suspect this was most likely because we were executing a bash script to run each of those tests, so the error was not being passed up correctly... the .sh file was simply exiting with exit code 0 so it though the tests ran successfully.

Now, each one individually is ran so that the exit code can be caught correctly.

This can be further improved on if we increase the number of unit tests by re-creating a new bash script that catches the exit code of each script and exits with a non-zero exit code if any of them error out during execution.