### PR TITLE
Add versioning for serving style.css file

### DIFF
--- a/helphours/templates/base.html
+++ b/helphours/templates/base.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/style.css') }}">
+        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/style.css', v='1.0') }}">
 
         <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='icons/apple-touch-icon.png') }}">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='icons/favicon-32x32.png') }}">


### PR DESCRIPTION
We previously had issues with old .css files being cached when we had some new functionality added to the site which results in the webpages looking weird. By appending the query string with a version to the end, we can now force the cached .css files in user browsers to be flushed for a newly fetched one.