### PR TITLE
Faster Queue Serialization

### DIFF
--- a/helphours/json_routes.py
+++ b/helphours/json_routes.py
@@ -6,14 +6,7 @@ from flask_login import current_user
 @app.route("/queue", methods=['GET'])
 def queue():
     """ Returns a JSON representation of the queue """
-    students = queue_handler.get_students()
-
-    if current_user.is_authenticated:
-        serialized_list = [students[i].serialize_instructor_view(i) for i in range(len(students))]
-    else:
-        serialized_list = [students[i].serialize_student_view(i) for i in range(len(students))]
-
-    return jsonify({'queue': serialized_list})
+    return queue_handler.get_serialized_queue(instructorView=current_user.is_authenticated)
 
 
 @app.route("/queue_status", methods=['GET'])

--- a/helphours/queue_handler.py
+++ b/helphours/queue_handler.py
@@ -1,3 +1,4 @@
+from flask import jsonify
 
 """
     Representation of the Queue in memory. This
@@ -5,6 +6,9 @@
     "front" of the queue.
 """
 student_queue = []
+
+serialized_student_view = None
+serialized_instructor_view = None
 
 """
     Enqueues a Student object to the end of the queue.
@@ -20,6 +24,7 @@ def enqueue(student):
 
     # add them to the queue, return their place in line
     student_queue.append(student)
+    generate_serialized_queues()
     return len(student_queue)
 
 
@@ -59,7 +64,8 @@ def remove(id):
     for i in range(0, len(student_queue)):
         if(id == student_queue[i].id):
             del student_queue[i]
-            break
+            generate_serialized_queues()
+            return
 
 
 """
@@ -73,6 +79,7 @@ def remove_eid(eid):
         if(eid == student_queue[i].eid):
             s = student_queue[i]
             del student_queue[i]
+            generate_serialized_queues()
             return s
     return None
 
@@ -85,3 +92,33 @@ def remove_eid(eid):
 def clear():
     global student_queue
     student_queue = []
+    generate_serialized_queues()
+
+
+"""
+    Handles creating a JSON representation of the queue
+    when the front-end polls the current queue
+"""
+
+
+def get_serialized_queue(instructorView=False):
+    if instructorView:
+        if serialized_instructor_view is None:
+            generate_serialized_queues()
+        return serialized_instructor_view
+    else:
+        if serialized_student_view is None:
+            generate_serialized_queues()
+        return serialized_student_view
+
+
+def generate_serialized_queues():
+    global serialized_instructor_view
+    global serialized_student_view
+    students = get_students()
+
+    instructor_serialized_list = [students[i].serialize_instructor_view(i) for i in range(len(students))]
+    serialized_instructor_view = jsonify({'queue': instructor_serialized_list})
+
+    student_serialized_list = [students[i].serialize_student_view(i) for i in range(len(students))]
+    serialized_student_view = jsonify({'queue': student_serialized_list})


### PR DESCRIPTION
When someone is on the "View Queue" page, the page quite frequently polls the `/queue` route to get a JSON representation of the queue that can be displayed on the front-end.

When this was (quickly & sloppily) implemented by me, I generated the JSON representation on every request made to the API. However, this is needlessly inefficient since we only need to generate this JSON when the queue _changes_.

So now, this JSON is only generated when the queue changes and is all handled in the `queue_handler.py` file rather than in the route function.

This should provide a considerable speed-up considering the "View Queue" page is assuredly the page people stay on the longest and how often the route is requested by each client.

Fixes #56 