### PR TITLE
Fix Missing "Time left" in DB when queue is cleared

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -249,7 +249,8 @@ def clear():
     expected_token = app.config['CLEAR_TOKEN']
     if request.form['token'] != expected_token:
         return json.dumps({'success': False}), 401, {'ContentType': 'application/json'}
-    queue_handler.clear()
+    for student in queue_handler.get_students():
+        routes_helper.remove_helper(student.id)
     log.info('Queue was cleared through /clear route')
     return json.dumps({'success': True}), 200, {'ContentType': 'application/json'}
 

--- a/helphours/routes_helper.py
+++ b/helphours/routes_helper.py
@@ -84,4 +84,4 @@ def remove_helper(uid, was_helped=False, instructor_id=None):
             v.wasHelped = 0
         db.session.commit()
     else:
-        log.error(f"DId not find entry for {uid} in the visits table.")
+        log.error(f"Did not find entry for {uid} in the visits table.")

--- a/helphours/routes_helper.py
+++ b/helphours/routes_helper.py
@@ -35,7 +35,7 @@ def handle_remove(request):
     elif 'removed' in request.form:
         uid = request.form['removed']
     # Remove the student from the queue and update the database
-    remove_helper(uid, was_helped=('finised' in request.form), instructor_id=g.user.id)
+    remove_helper(uid, was_helped=('finished' in request.form), instructor_id=g.user.id)
 
     # Notify runner-up in the queue
     s = queue_handler.peek_runner_up()


### PR DESCRIPTION
Refactors a bit of the logic for removing students from the queue and when the queue is cleared, the students removed have the correct timestamp added to "time left" in the database.

Fixes #49 