### PR TITLE
Add regular expression validation for EID token

### DIFF
--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField, PasswordField, BooleanField
-from wtforms.validators import DataRequired, Length, Email, EqualTo
+from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp
 
 
 class JoinQueueForm(FlaskForm):
@@ -13,7 +13,8 @@ class JoinQueueForm(FlaskForm):
         Email()
     ])
     eid = StringField('EID', validators=[
-        DataRequired()
+        DataRequired(),
+        Regexp('^[a-zA-Z0-9]+$', message="Not a valid EID token")
     ])
     submit = SubmitField('Join the Queue!')
 

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -14,7 +14,7 @@ class JoinQueueForm(FlaskForm):
     ])
     eid = StringField('EID', validators=[
         DataRequired(),
-        Regexp('^[a-zA-Z0-9]+$', message="Please only enter alphanumeric characters.")
+        Regexp('^[a-zA-Z0-9]+$', message="Please only enter alphanumeric characters for EID field")
     ])
     submit = SubmitField('Join the Queue!')
 

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -14,7 +14,7 @@ class JoinQueueForm(FlaskForm):
     ])
     eid = StringField('EID', validators=[
         DataRequired(),
-        Regexp('^[a-zA-Z0-9]+$', message="Not a valid EID token")
+        Regexp('^[a-zA-Z0-9]+$', message="Please only enter alphanumeric characters.")
     ])
     submit = SubmitField('Join the Queue!')
 

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -54,7 +54,7 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data, visit.id)
+                        form.eid.data.lower(), visit.id)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Lab Hours Queue",

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -54,7 +54,7 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data.lower(), visit.id)
+                        form.eid.data, visit.id)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Lab Hours Queue",


### PR DESCRIPTION
No validation results in undefined behavior later on when attempting to perform stats analysis on the database, this should hopefully fix it.

The regular expression will force the user to input a single token with any chars a-z, A-Z, 0-9 acceptable. Any special tokens or multiple words (as in, any spaces) will cause the form to reject the input.