### PR TITLE
Queue Polling Improvements

### DIFF
--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -1,10 +1,23 @@
-const UPDATE_INTERVAL_SECONDS = 5;
+// How many seconds we should wait before polling the server again
+const UPDATE_INTERVAL_SECONDS = 10;
+
+// After 120 minutes of not refreshing the page or clicking any buttons
+// stop making requests to the API
+const TIMEOUT_MINUTES = 120;
 
 // Hold previous fetch result, if it's the same, don't bother re-rendering
 var lastPullResponse;
 
+// Fetch the queue when the page loads
 updateQueue();
-setInterval(updateQueue, UPDATE_INTERVAL_SECONDS * 1000);
+
+var updateInterval = setInterval(updateQueue, UPDATE_INTERVAL_SECONDS * 1000);
+
+setTimeout(() => {
+    clearInterval(updateInterval);
+    clearQueue();
+    displayMessage('Connection timed out, refresh the page.')
+}, TIMEOUT_MINUTES * 60 * 1000);
 
 
 function updateQueue() {
@@ -20,15 +33,15 @@ function updateQueue() {
 function renderQueue(data) {
     let dataJSON = JSON.stringify(data);
     if(lastPullResponse === dataJSON){
+        // Nothing changed, don't bother re-rendering
         return;
-    } else {
-        clearQueue();
-        lastPullResponse = dataJSON;
     }
 
+    // Queue changed, let's re-render and save this result
+    clearQueue();
+    lastPullResponse = dataJSON;
 
     let queue = data.queue;
-
 
     if (!queue || queue.length === 0) {
         displayMessage('The queue is empty.');
@@ -36,7 +49,7 @@ function renderQueue(data) {
     else {
         let queueContainer = document.getElementById("queue");
         let template = document.getElementById("queue-entry-template");
-        for (var i = 0; i < queue.length; i++) {
+        for (let i = 0; i < queue.length; i++) {
             let newEntry = template.content.cloneNode(true);
             newEntry.querySelector('.queue-entry-position').textContent = queue[i].position;
             newEntry.querySelector('.queue-entry-name').textContent = queue[i].name;


### PR DESCRIPTION
Two minor changes to the way we retrieve the queue.

## Client Connection Timeout

If a client is on the view queue page for a long amount of time (perhaps the website is running in the background) their connection will time out. Instructors using the "Help/Remove" buttons counts as "refreshing" the page, so this shouldn't be an issue for instructors who may be on the page while holding help hours.

Currently this timeout is set to 2 hours.

## Slower Poll Rate

I've halved the polling rate from every 5 seconds to every 10 seconds. Hopefully this will help ease some server load as we increase the number of sites being run. If we find this to be too slow, we could always change it back (or have it vary based on instructor/student view).