### PR TITLE
Adds Problem Description For Queue Entries

### DIFF
--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -16,6 +16,9 @@ class JoinQueueForm(FlaskForm):
         DataRequired(),
         Regexp('^[a-zA-Z0-9]+$', message="Please only enter alphanumeric characters for EID field")
     ])
+    desc = StringField('Short Problem Description', validators=[
+        DataRequired()
+    ])
     submit = SubmitField('Join the Queue!')
 
 

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -6,7 +6,7 @@ from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp
 class JoinQueueForm(FlaskForm):
     name = StringField('Name', validators=[
         DataRequired(),
-        Length(min=2, max=30)
+        Length(min=2, max=32, message="Please limit name entry to 32 characters.")
     ])
     email = StringField('Email', validators=[
         DataRequired(),

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -54,7 +54,7 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data, visit.id)
+                        form.eid.data, form.desc.data, visit.id)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Lab Hours Queue",

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -400,7 +400,7 @@ textarea {
 
 
 .queue-container {
-    width: 60%;
+    width: 75%;
     height: 100%;
     margin-left: auto;
     margin-right: auto;
@@ -410,19 +410,79 @@ textarea {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
-    padding: 12px 20px;
+    align-items: center; 
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.queue-entry-box {
+    padding: 12px;
     -webkit-box-shadow: 5px 5px 10px #ccc;
             box-shadow: 5px 5px 10px #ccc;
     border-radius: 5px;
     background-color: #eee;
-    margin-bottom: 20px;
+    /* width: 80%; */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    /* overflow: hidden; */
+    white-space: nowrap;
+    transition: 0.4s;
+    z-index: 2;
 }
 
-.dark .queue-entry {
+.queue-entry-box.active {
+    border-radius: 5px 5px 0px 0px;
+}
+
+.dark .queue-entry-box {
     -webkit-box-shadow: none;
             box-shadow: none;
     border: 1px solid white;
     background-color: inherit;
+}
+
+.queue-entry-wrapper {
+    flex-grow: 1;
+    max-width: 90%;
+}
+
+.queue-entry-expand-toggle {
+    /* max-width: 50%; */
+    overflow: hidden;
+}
+
+.queue-entry-expanded {
+   /* width: 100%;  */
+   background-color: #ddd;
+   border-radius: 0px 0px 5px 5px;
+   padding: 15px;
+    -webkit-box-shadow: 5px 5px 10px #ccc;
+            box-shadow: 5px 5px 10px #ccc;
+   margin-top: -2px;
+   display: none;
+}
+
+.dark .queue-entry-expanded {
+    background-color: #444;
+    box-shadow: none;
+    border: 1px solid white;
+}
+
+.queue-entry-expanded.active {
+    display: block;
+}
+
+.queue-chevron {
+    width: 10px;
+    flex-shrink: 0;
+    margin-right: 5px;
+    transform: rotate(270deg);
+    transition: transform 0.1s ease-in;
+}
+
+.queue-entry-box.active .queue-chevron{
+    transform: rotate(360deg);
 }
 
 .queue-entry-left {
@@ -432,11 +492,20 @@ textarea {
         align-self: center;
 }
 
+.queue-entry-desc {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    margin: 0px 20px;
+    font-size: 80%;
+    flex-shrink: 1;
+}
+
 .queue-entry-right {
     margin-left: auto;
     -ms-flex-item-align: center;
         -ms-grid-row-align: center;
         align-self: center;
+    white-space: nowrap;
 }
 
 .queue-entry-buttons {
@@ -448,6 +517,7 @@ textarea {
     font-weight: bold;
     font-size: 130%;
     color: #777;
+    margin: 10px;
 }
 
 .dark .queue-entry-position {
@@ -458,7 +528,7 @@ textarea {
     display: inline-block;
     font-weight: bold;
     font-size: 120%;
-    margin-left: 20px;
+    /* margin-left: 20px; */
 }
 
 .queue-controls {

--- a/helphours/student.py
+++ b/helphours/student.py
@@ -4,10 +4,11 @@ class Student:
         Class to represent a Student entry in the
         Lab Hours Queue.
     """
-    def __init__(self, name, email, eid, uid):
+    def __init__(self, name, email, eid, desc, uid):
         self.name = name
         self.email = email
         self.eid = eid
+        self.desc = desc
         # Whether or not we've sent an email to this
         # student indicating they're next in line
         self.notified = False
@@ -27,5 +28,6 @@ class Student:
         return {
             'name': self.name,
             'position': position,
+            'desc': self.desc,
             'id': self.id
         }

--- a/helphours/templates/join.html
+++ b/helphours/templates/join.html
@@ -26,6 +26,11 @@
                 {{ form.eid(class="form-input") }}
             </div>
 
+            <div>
+                {{ form.desc.label(class="form-label") }}
+                {{ form.desc(class="form-input") }}
+            </div>
+
             {% if message|length > 0 %}
                 <p class="error-message">{{ message }}</p>
             {% endif %}

--- a/helphours/templates/view.html
+++ b/helphours/templates/view.html
@@ -30,17 +30,31 @@
     <script src="{{ url_for('static', filename='scripts/queue.js') }}"></script>
 </div>
 
+
 <template id="queue-entry-template">
     <div class="queue-entry">
-        <div class="queue-entry-left">
-            <div class="queue-entry-position"></div>
-            <div class="queue-entry-name"></div>
-        </div>
-        <div class="queue-entry-right">
-            <form method="POST" class="queue-entry-buttons">
-                <button class="helped-button" name="finished">Start Helping</button>
-                <button class="remove-button" name="removed">Remove</button>
-            </form>
+        <div class="queue-entry-position"></div>
+        <div class="queue-entry-wrapper">
+            <div class="queue-entry-box">
+                <div class="queue-entry-expand-toggle">
+                    <svg class="queue-chevron" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid meet" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="#626262"/><rect x="0" y="0" width="1200" height="1200" fill="rgba(0, 0, 0, 0)" /></svg>
+                    <div class="queue-entry-name"></div>
+                </div>
+                <div class="queue-entry-right">
+                    <form method="POST" class="queue-entry-buttons">
+                        <button class="helped-button" name="finished">Start Helping</button>
+                        <button class="remove-button" name="removed">Remove</button>
+                    </form>
+                </div>
+            </div>
+            <div class="queue-entry-expanded">
+                <div>
+                    <strong>Description: </strong> <span class="queue-entry-expanded-desc"></span>
+                </div>
+                <div>
+                    <strong>In queue since: </strong><span class="queue-entry-expanded-time"></span>
+                </div>
+            </div>
         </div>
     </div>
 </template>

--- a/tests/student_tests.py
+++ b/tests/student_tests.py
@@ -8,22 +8,27 @@ from student import Student
 class TestStudent(unittest.TestCase):
 
     def test_name(self):
-        x = Student("John Doe", "john@gmail.com", "jd123", "")
+        x = Student("John Doe", "john@gmail.com", "jd123", "Help", "")
         self.assertEqual("John Doe", x.name)
 
     def test_email(self):
-        x = Student("John Doe", "john@gmail.com", "jd123", "")
+        x = Student("John Doe", "john@gmail.com", "jd123", "Help", "")
         self.assertEqual("john@gmail.com", x.email)
 
     def test_eid(self):
-        x = Student("John Doe", "john@gmail.com", "jd123", "")
+        x = Student("John Doe", "john@gmail.com", "jd123", "Help", "")
         self.assertEqual("jd123", x.eid)
 
+    def test_desc(self):
+        x = Student("John Doe", "john@gmail.com", "jd123", "Help", "")
+        self.assertEqual("Help", x.desc)
+
     def test_combined(self):
-        x = Student("Jane Doe", "jane@gmail.com", "jd1234", "")
+        x = Student("Jane Doe", "jane@gmail.com", "jd1234", "Need help", "")
         self.assertEqual("Jane Doe", x.name)
         self.assertEqual("jane@gmail.com", x.email)
         self.assertEqual("jd1234", x.eid)
+        self.assertEqual("Need help", x.desc)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Upon wanting to enter the queue, students will need to provide a short description of their problem.

Instructors will be able to see this description in the View Queue page by expanding their entry.
(I also added an "In Queue Since" field with the extra room)

This does not change anything in the database, only what is stored in the queue and Student objects themselves.

## Light Mode
![join](https://user-images.githubusercontent.com/24216390/97067988-92556800-1580-11eb-9970-6903c480663a.png)
![light-closed](https://user-images.githubusercontent.com/24216390/97067955-486c8200-1580-11eb-85a3-d4b8162dab1f.png)
![light-open](https://user-images.githubusercontent.com/24216390/97067956-4a364580-1580-11eb-9b09-7008c0d0a1c1.png)


## Dark Mode
![join-dark](https://user-images.githubusercontent.com/24216390/97067990-94b7c200-1580-11eb-8aa3-7bcb1d2296cb.png)
![dark-closed](https://user-images.githubusercontent.com/24216390/97067958-4e626300-1580-11eb-9aaa-801736fc5ac3.png)
![dark-open](https://user-images.githubusercontent.com/24216390/97067960-502c2680-1580-11eb-9b45-8253275f62e6.png)

## Todo?

- An "expand all" button?
- Maybe we should make the non-expanded entries smaller still?