### PR TITLE
Added weekend options for Zoom links

### DIFF
--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -95,6 +95,8 @@ class AddZoomLinkForm(FlaskForm):
         (3, 'Wednesday'),
         (4, 'Thursday'),
         (5, 'Friday'),
+        (6, 'Saturday'),
+        (7, 'Sunday')
     ])
     submit = SubmitField('Add Link')
 
@@ -104,6 +106,6 @@ class RemoveZoomLinkForm(FlaskForm):
     submit = SubmitField('Remove Link')
 
     def set_choices(self):
-        days = ["Other", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+        days = ["Other", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
         self.links.choices = [(-1, "---")] + [(link.id, str(link.description + ", " + days[int(link.day)]))
                                               for link in ZoomLink.query.order_by(ZoomLink.day).all()]

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -114,14 +114,13 @@ def remove():
 
 @app.route("/zoom", methods=['GET'])
 def zoom_links():
-    links = [ZoomLink.query.filter(ZoomLink.day == 0).all()]
-    links += [ZoomLink.query.filter(ZoomLink.day == 1).all()]
-    links += [ZoomLink.query.filter(ZoomLink.day == 2).all()]
-    links += [ZoomLink.query.filter(ZoomLink.day == 3).all()]
-    links += [ZoomLink.query.filter(ZoomLink.day == 4).all()]
-    links += [ZoomLink.query.filter(ZoomLink.day == 5).all()]
+    links = []
+    for day in range(0, 8):
+        links += [ZoomLink.query.filter(ZoomLink.day == day).all()]
     show_cal = len(links[0]) != len(ZoomLink.query.all())
-    return render_template('zoom.html', links=links, show_cal=show_cal)
+    show_weekends = len(links[6]) + len(links[7]) > 0
+    return render_template('zoom.html', links=links,
+                           show_cal=show_cal, show_weekends=show_weekends)
 
 
 @app.route('/change_zoom', methods=['GET', 'POST'])

--- a/helphours/templates/zoom.html
+++ b/helphours/templates/zoom.html
@@ -70,6 +70,28 @@
             </a>
             {% endfor %}
         </div>
+        {% if show_weekends %}
+        <div class="column" style=" margin: 1%;">
+            <h2 style="text-align: center;">Saturday</h2>
+            {% for link in links[6] %}
+            <a class="meeting-link" href="{{ link.url }}" target="_blank">
+                <div class="link-entry">
+                    <div class="link-desc">{{ link.description }}</div>
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+        <div class="column" style="margin: 1%;">
+            <h2 style="text-align: center;">Sunday</h2>
+            {% for link in links[7] %}
+            <a class="meeting-link" href="{{ link.url }}" target="_blank">
+                <div class="link-entry">
+                    <div class="link-desc">{{ link.description }}</div>
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+        {% endif %}
     </div>
     {% endif %}
 


### PR DESCRIPTION
Adds the option to have Zoom links be scheduled for weekends.

Adds Saturday and Sunday to the drop-down menu.
Will only show Saturday & Sunday columns if any links are added for those days:
https://github.com/SamLab17/HelpHours/blob/9b89e805ff549bc3f1d66d2d014be5f0ece3c5cc/helphours/routes.py#L121

Please make sure there are no typos or obvious errors anywhere!