### PR TITLE
Temporarily Disable Stats Page

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -1,6 +1,7 @@
 import json
 import secrets
-from helphours import app, log, db, notifier, queue_handler, routes_helper, password_reset, stats
+from helphours import app, log, db, notifier, queue_handler, routes_helper, password_reset
+# from helphours import stats
 from flask import render_template, url_for, redirect, request, g, send_from_directory
 from helphours.forms import JoinQueueForm, RemoveSelfForm, InstructorForm, AddZoomLinkForm, RemoveZoomLinkForm
 from helphours.student import Student
@@ -259,11 +260,12 @@ def add_instructor():
 @app.route('/stats', methods=['GET', 'POST'])
 @login_required
 def stats_page():
-    if 'range' not in request.args:
-        range = "all"
-    else:
-        range = request.args['range']
-    return stats.get_graphs(range)
+    return render_template('unavailable.html', title="Stats")
+    # if 'range' not in request.args:
+    #     range = "all"
+    # else:
+    #     range = request.args['range']
+    # return stats.get_graphs(range)
 
 
 @app.route('/about', methods=['GET'])

--- a/helphours/templates/stats.html
+++ b/helphours/templates/stats.html
@@ -8,7 +8,6 @@
 
 <div class="">
         <h2>Help Hours Stats</h2> 
-        </span>
         <div class="stats-nav-container">
             <ul class="stats-nav">
                 <li>

--- a/helphours/templates/stats.html
+++ b/helphours/templates/stats.html
@@ -7,7 +7,8 @@
 {% block body %}
 
 <div class="">
-        <h2>Lab Hours Stats</h2> 
+        <h2>Help Hours Stats</h2> 
+        </span>
         <div class="stats-nav-container">
             <ul class="stats-nav">
                 <li>

--- a/helphours/templates/unavailable.html
+++ b/helphours/templates/unavailable.html
@@ -7,6 +7,6 @@
 {% block body %}
 <div>
     <h1>{{ title }}</h1>
-    <span>Sorry, this page is currently unavailable as it is under maintenance.
+    <span>Sorry, this page is currently unavailable as it is under maintenance.</span>
 </div>
 {% endblock %}

--- a/helphours/templates/unavailable.html
+++ b/helphours/templates/unavailable.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block head %}
+<title>Stats</title>
+{% endblock %}
+
+{% block body %}
+<div>
+    <h1>{{ title }}</h1>
+    <span>Sorry, this page is currently unavailable as it is under maintenance.
+</div>
+{% endblock %}


### PR DESCRIPTION
These changes temporarily disable the stats page in hopes that not having to import the packages used in the stats module will save some memory. 

This should only be a temporary fix while we try to resolve the issue which caused the 314 app to crash on Thursday 3/4.