### PR TITLE
Use signals that work better with flask instead of atexit

### DIFF
--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -51,7 +51,7 @@ except:  # noqa: E722
     pass
 
 
-def save_queue():
+def save_queue(sender, **args):
     try:
         with open(app.config['QUEUE_FILE'], "wb") as file:
             dump_data = (routes.queue_is_open, queue_handler.get_students())
@@ -61,5 +61,5 @@ def save_queue():
         pass
 
 
-import atexit
-atexit.register(save_queue)
+from flask import appcontext_tearing_down
+appcontext_tearing_down.connect(save_queue, app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 astroid==2.4.2
 autopep8==1.5.4
+blinker==1.4
 click==7.1.2
 cycler==0.10.0
 decorator==4.4.2


### PR DESCRIPTION
appcontext_tearing_down is more reliable to use with Flask apps because it is from Flask's integrated signaling support. Note the changes to requirements.txt.