### PR TITLE
Add notifying runner-ups when student removes self from queue

### DIFF
--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -102,7 +102,7 @@ def remove():
                     try:
                         log.debug(f"Sending runner up email to {runner_up.email}")
                         notifier.send_message(
-                            s.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
+                            runner_up.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
                             render_template(
                                 "email/up_next_email.html", student_name=runner_up.name,
                                 remove_code=runner_up.eid, view_link=app.config['WEBSITE_LINK'] + url_for('view')),

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -95,6 +95,19 @@ def remove():
             # remove em
             s = queue_handler.remove_eid(form.eid.data)
             if s is not None:
+
+                # Notify runner-up in the queue
+                runner_up = queue_handler.peek_runner_up()
+                if runner_up is not None and not runner_up.notified:
+                    try:
+                        log.debug(f"Sending runner up email to {runner_up.email}")
+                        notifier.send_message(s.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
+                                            render_template("email/up_next_email.html", student_name=runner_up.name, remove_code=runner_up.eid,
+                                                            view_link=app.config['WEBSITE_LINK'] + url_for('view')), 'html')
+                        s.notified = True
+                    except Exception as e:
+                        log.warning(f"Failed to send email to {runner_up.email}. {e}")
+
                 v = Visit.query.filter_by(id=s.id).first()
                 if v is not None:
                     v.time_left = datetime.utcnow()

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -101,12 +101,11 @@ def remove():
                 if runner_up is not None and not runner_up.notified:
                     try:
                         log.debug(f"Sending runner up email to {runner_up.email}")
-                        notifier.send_message(s.email,
+                        notifier.send_message(  s.email,
                                                 f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
-                                                    render_template("email/up_next_email.html",
-                                                        student_name=runner_up.name, remove_code=runner_up.eid,
-                                                            view_link=app.config['WEBSITE_LINK'] + url_for('view')),
-                                                                'html')
+                                                render_template("email/up_next_email.html",
+                                                student_name=runner_up.name, remove_code=runner_up.eid,
+                                                view_link=app.config['WEBSITE_LINK'] + url_for('view')), 'html')
                         s.notified = True
                     except Exception as e:
                         log.warning(f"Failed to send email to {runner_up.email}. {e}")

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -108,7 +108,7 @@ def remove():
                                 remove_code=runner_up.eid, view_link=app.config['WEBSITE_LINK'] + url_for('view')),
                             'html')
 
-                        s.notified = True
+                        runner_up.notified = True
                     except Exception as e:
                         log.warning(f"Failed to send email to {runner_up.email}. {e}")
 

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -101,11 +101,13 @@ def remove():
                 if runner_up is not None and not runner_up.notified:
                     try:
                         log.debug(f"Sending runner up email to {runner_up.email}")
-                        notifier.send_message(  s.email,
-                                                f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
-                                                render_template("email/up_next_email.html",
-                                                student_name=runner_up.name, remove_code=runner_up.eid,
-                                                view_link=app.config['WEBSITE_LINK'] + url_for('view')), 'html')
+                        notifier.send_message(
+                            s.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
+                            render_template(
+                                "email/up_next_email.html", student_name=runner_up.name,
+                                remove_code=runner_up.eid, view_link=app.config['WEBSITE_LINK'] + url_for('view')),
+                            'html')
+
                         s.notified = True
                     except Exception as e:
                         log.warning(f"Failed to send email to {runner_up.email}. {e}")

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -101,9 +101,12 @@ def remove():
                 if runner_up is not None and not runner_up.notified:
                     try:
                         log.debug(f"Sending runner up email to {runner_up.email}")
-                        notifier.send_message(s.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
-                                            render_template("email/up_next_email.html", student_name=runner_up.name, remove_code=runner_up.eid,
-                                                            view_link=app.config['WEBSITE_LINK'] + url_for('view')), 'html')
+                        notifier.send_message(s.email,
+                                                f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
+                                                    render_template("email/up_next_email.html",
+                                                        student_name=runner_up.name, remove_code=runner_up.eid,
+                                                            view_link=app.config['WEBSITE_LINK'] + url_for('view')),
+                                                                'html')
                         s.notified = True
                     except Exception as e:
                         log.warning(f"Failed to send email to {runner_up.email}. {e}")


### PR DESCRIPTION
Previously, we notified runner-up students with an email only when an instructor removes students from the queue. However, we now always notify students no matter whether a student removes themselves from the queue or if an instructor removes them.