### PR TITLE
In person queue join page

### DIFF
--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -65,6 +65,5 @@ def save_queue(sender, **args):
         pass
 
 
-
 from flask import appcontext_tearing_down
 appcontext_tearing_down.connect(save_queue, app)

--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -9,6 +9,10 @@ app.config.from_pyfile('config.cfg')
 
 app.jinja_env.auto_reload = True
 
+# Default DUAL_MODAILTY option to false.
+if 'DUAL_MODALITY' not in app.config:
+    app.config['DUAL_MODALITY'] = False
+
 db = SQLAlchemy(app)
 
 login = LoginManager(app)
@@ -61,9 +65,6 @@ def save_queue(sender, **args):
         pass
 
 
-# Default DUAL_MODAILTY option to false.
-if 'DUAL_MODALITY' not in app.config:
-    app.config['DUAL_MODALITY'] = False
 
 from flask import appcontext_tearing_down
 appcontext_tearing_down.connect(save_queue, app)

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -1,7 +1,9 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField, PasswordField, BooleanField, SelectField
-from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp, ValidationError
+from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp, ValidationError, NoneOf
 from helphours.models.zoom_link import ZoomLink
+from helphours.student import Student
+from helphours import app
 import validators
 
 
@@ -20,6 +22,18 @@ class JoinQueueForm(FlaskForm):
     ])
     desc = StringField('Short Problem Description', validators=[
         DataRequired()
+    ])
+
+    default_opt = ('', 'Choose Format')
+    remote_opt = (Student.REMOTE, 'Remote')
+    in_person_opt = (Student.IN_PERSON, 'In Person')
+
+    # If dual modality is not enabled, use 'remote'
+    modality_default = None if app.config['DUAL_MODALITY'] else Student.REMOTE
+    modality = SelectField('Format', choices=[default_opt, remote_opt, in_person_opt], 
+                           default=modality_default, validators=[
+        DataRequired(),
+        NoneOf(default_opt)
     ])
     submit = SubmitField('Join the Queue!')
 

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -30,7 +30,7 @@ class JoinQueueForm(FlaskForm):
 
     # If dual modality is not enabled, use 'remote'
     modality_default = None if app.config['DUAL_MODALITY'] else Student.REMOTE
-    modality = SelectField('Format', choices=[default_opt, remote_opt, in_person_opt], 
+    modality = SelectField('Format', choices=[default_opt, remote_opt, in_person_opt],
                            default=modality_default, validators=[
         DataRequired(),
         NoneOf(default_opt)

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -62,13 +62,15 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data, form.desc.data, visit.id, Student.REMOTE)
+                        form.eid.data, form.desc.data, visit.id, form.modality.data)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Help Hours Queue",
                                   render_template("email/added_to_queue_email.html",
-                                                  view_link=app.config['WEBSITE_LINK'] + url_for('view'),
-                                                  place_str=routes_helper.get_place_str(place),
+                                                  view_link=app.config['WEBSITE_LINK'] + url_for(
+                                                      'view'),
+                                                  place_str=routes_helper.get_place_str(
+                                                      place),
                                                   student_name=form.name.data, remove_code=form.eid.data),
                                   'html')
             return redirect(url_for('view'))
@@ -76,7 +78,8 @@ def join():
             if len(form.errors) > 0:
                 message = next(iter(form.errors.values()))[0]
     # render the template for submitting otherwise
-    return render_template('join.html', form=form, queue_is_open=queue_is_open, message=message)
+    return render_template('join.html', form=form, dual_modality=app.config['DUAL_MODALITY'],
+                           queue_is_open=queue_is_open, message=message)
 
 
 @app.route("/view", methods=['GET', 'POST'])
@@ -107,7 +110,8 @@ def remove():
                 runner_up = queue_handler.peek_runner_up()
                 if runner_up is not None and not runner_up.notified:
                     try:
-                        log.debug(f"Sending runner up email to {runner_up.email}")
+                        log.debug(
+                            f"Sending runner up email to {runner_up.email}")
                         notifier.send_message(
                             runner_up.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
                             render_template(
@@ -117,7 +121,8 @@ def remove():
 
                         runner_up.notified = True
                     except Exception as e:
-                        log.warning(f"Failed to send email to {runner_up.email}. {e}")
+                        log.warning(
+                            f"Failed to send email to {runner_up.email}. {e}")
 
                 v = Visit.query.filter_by(id=s.id).first()
                 if v is not None:
@@ -127,7 +132,8 @@ def remove():
                     return redirect(url_for('view'))
                 else:
                     # Serious issue, there are inconsistencies in the database.
-                    log.error('Student in queue does not have a corresponding entry in visits table.', notify=True)
+                    log.error(
+                        'Student in queue does not have a corresponding entry in visits table.', notify=True)
                     return render_template('message_error.html', title="Error Removing from queue",
                                            body="Sorry, something went wrong when trying to remove you from the queue.")
             else:
@@ -165,7 +171,8 @@ def change_zoom():
 
             db.session.add(new_link)
             db.session.commit()
-            log.info(f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
+            log.info(
+                f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
 
             form = AddZoomLinkForm()
             form.url.data = ""
@@ -176,10 +183,12 @@ def change_zoom():
 
     elif remove_form.validate_on_submit() and remove_form.links.data is not None:
         if int(remove_form.links.data) != -1:
-            db.session.delete(ZoomLink.query.filter(ZoomLink.id == int(remove_form.links.data)).first())
+            db.session.delete(ZoomLink.query.filter(
+                ZoomLink.id == int(remove_form.links.data)).first())
             db.session.commit()
 
-            log.info(f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
+            log.info(
+                f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
             remove_message = "The zoom link has been removed!"
         else:
             remove_message = "Please select a link to remove"
@@ -236,7 +245,8 @@ def edit_instructor():
                 instr.is_active = 1 if form.is_active.data else 0
                 instr.is_admin = 1 if form.is_admin.data else 0
                 db.session.commit()
-                log.info(f'The account for {instr.first_name} {instr.last_name} was updated.')
+                log.info(
+                    f'The account for {instr.first_name} {instr.last_name} was updated.')
                 return redirect('admin_panel')
             else:
                 message = 'Enter a valid email address'
@@ -272,7 +282,8 @@ def add_instructor():
                 db.session.add(instr)
                 db.session.commit()
                 password_reset.new_user(instr)
-                log.info(f'New account created for {instr.first_name} {instr.last_name}.')
+                log.info(
+                    f'New account created for {instr.first_name} {instr.last_name}.')
                 return redirect('admin_panel')
             else:
                 message = 'Enter a valid email address'

--- a/helphours/templates/join.html
+++ b/helphours/templates/join.html
@@ -31,6 +31,13 @@
                 {{ form.desc(class="form-input", autocomplete="off") }}
             </div>
 
+            {% if dual_modality %}
+            <div>
+                {{ form.modality.label(class="form-label") }}
+                {{ form.modality(class="form-input") }}
+            </div>
+            {% endif %}
+
             {% if message|length > 0 %}
                 <p class="error-message">{{ message }}</p>
             {% endif %}


### PR DESCRIPTION
"Join Queue" page with modality option.

On the front-end I changed modality to "Format" (maybe Mike will like that more lol). We can change this if it makes the code too inconsistent.

If `DUAL_MODALITY` isn't enabled, then the dropdown doesn't show up on the join page and it defaults to "remote".

**TODO:**
- The "join" button has some Javascript that disables it if the queue is closed. This will need to change with 2 queues that can open/close. We can do this once the opening/closing of both queues has been implemented.