### PR TITLE
Virtual and In-Person Queues

### DIFF
--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -9,6 +9,10 @@ app.config.from_pyfile('config.cfg')
 
 app.jinja_env.auto_reload = True
 
+# Default DUAL_MODAILTY option to false.
+if 'DUAL_MODALITY' not in app.config:
+    app.config['DUAL_MODALITY'] = False
+
 db = SQLAlchemy(app)
 
 login = LoginManager(app)
@@ -60,10 +64,6 @@ def save_queue(sender, **args):
         log.info('Error while writing last queue state')
         pass
 
-
-# Default DUAL_MODAILTY option to false.
-if 'DUAL_MODALITY' not in app.config:
-    app.config['DUAL_MODALITY'] = False
 
 from flask import appcontext_tearing_down
 appcontext_tearing_down.connect(save_queue, app)

--- a/helphours/__init__.py
+++ b/helphours/__init__.py
@@ -61,5 +61,9 @@ def save_queue(sender, **args):
         pass
 
 
+# Default DUAL_MODAILTY option to false.
+if 'DUAL_MODALITY' not in app.config:
+    app.config['DUAL_MODALITY'] = False
+
 from flask import appcontext_tearing_down
 appcontext_tearing_down.connect(save_queue, app)

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -25,12 +25,12 @@ class JoinQueueForm(FlaskForm):
     ])
 
     default_opt = ('', 'Choose Format')
-    remote_opt = (Student.REMOTE, 'Remote')
-    in_person_opt = (Student.IN_PERSON, 'In Person')
+    virtual_opt = (Student.VIRTUAL, 'Virtual')
+    in_person_opt = (Student.IN_PERSON, 'In-Person')
 
-    # If dual modality is not enabled, use 'remote'
-    modality_default = None if app.config['DUAL_MODALITY'] else Student.REMOTE
-    modality = SelectField('Format', choices=[default_opt, remote_opt, in_person_opt],
+    # If dual modality is not enabled, use 'virtual'
+    modality_default = None if app.config['DUAL_MODALITY'] else Student.VIRTUAL
+    modality = SelectField('Format', choices=[default_opt, virtual_opt, in_person_opt],
                            default=modality_default, validators=[
         DataRequired(),
         NoneOf(default_opt)

--- a/helphours/forms.py
+++ b/helphours/forms.py
@@ -1,7 +1,9 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField, PasswordField, BooleanField, SelectField
-from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp, ValidationError
+from wtforms.validators import DataRequired, Length, Email, EqualTo, Regexp, ValidationError, NoneOf
 from helphours.models.zoom_link import ZoomLink
+from helphours.student import Student
+from helphours import app
 import validators
 
 
@@ -20,6 +22,18 @@ class JoinQueueForm(FlaskForm):
     ])
     desc = StringField('Short Problem Description', validators=[
         DataRequired()
+    ])
+
+    default_opt = ('', 'Choose Format')
+    remote_opt = (Student.REMOTE, 'Remote')
+    in_person_opt = (Student.IN_PERSON, 'In Person')
+
+    # If dual modality is not enabled, use 'remote'
+    modality_default = None if app.config['DUAL_MODALITY'] else Student.REMOTE
+    modality = SelectField('Format', choices=[default_opt, remote_opt, in_person_opt],
+                           default=modality_default, validators=[
+        DataRequired(),
+        NoneOf(default_opt)
     ])
     submit = SubmitField('Join the Queue!')
 

--- a/helphours/json_routes.py
+++ b/helphours/json_routes.py
@@ -15,5 +15,4 @@ def queue():
 
 @app.route("/queue_status", methods=['GET'])
 def queue_status():
-    status = 'OPEN' if g.queue_is_open else 'CLOSED'
-    return jsonify({'status': status})
+    return jsonify({'virtual_open': g.queue_is_open, 'in_person_open': g.in_person_queue_is_open})

--- a/helphours/json_routes.py
+++ b/helphours/json_routes.py
@@ -15,4 +15,5 @@ def queue():
 
 @app.route("/queue_status", methods=['GET'])
 def queue_status():
-    return jsonify({'virtual_open': g.queue_is_open, 'in_person_open': g.in_person_queue_is_open})
+    def sanitize(x): return False if x is None else x
+    return jsonify({'virtual_open': sanitize(g.queue_is_open), 'in_person_open': sanitize(g.in_person_queue_is_open)})

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -14,6 +14,9 @@ from werkzeug.security import generate_password_hash
 # Would likely need to be stored in a databse if we want multiple instances of this
 # running
 queue_is_open = False
+in_person_queue_is_open = None
+if app.config['DUAL_MODALITY']:
+    in_person_queue_is_open = True
 
 # Duck image to use during the day when the queue is open
 QUEUE_OPEN_DUCK = 'https://utcshelphours.com/duck.png'
@@ -30,6 +33,7 @@ CURRENT_DUCK = QUEUE_OPEN_DUCK
 def inject_variables():
     g.user = current_user
     g.queue_is_open = queue_is_open
+    g.in_person_queue_is_open = in_person_queue_is_open
 
 
 @app.context_processor
@@ -85,10 +89,14 @@ def join():
 @app.route("/view", methods=['GET', 'POST'])
 def view():
     global queue_is_open
+    global in_person_queue_is_open
     if request.method == "POST" and current_user.is_authenticated:
-        queue_is_open = routes_helper.handle_line_form(request, queue_is_open)
+        queue_is_open, in_person_queue_is_open = routes_helper.handle_line_form(request,
+                                                                                queue_is_open,
+                                                                                in_person_queue_is_open)
     queue = queue_handler.get_students()
-    return render_template('view.html', queue=queue, queue_is_open=queue_is_open)
+    return render_template('view.html', queue=queue, queue_is_open=queue_is_open,
+                           in_person_queue_is_open=in_person_queue_is_open)
 
 
 @app.route("/line", methods=['GET', 'POST'])

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -62,7 +62,7 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data, form.desc.data, visit.id)
+                        form.eid.data, form.desc.data, visit.id, Student.REMOTE)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Help Hours Queue",

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -62,13 +62,15 @@ def join():
             db.session.add(visit)
             db.session.commit()
             s = Student(form.name.data, form.email.data,
-                        form.eid.data, form.desc.data, visit.id, Student.REMOTE)
+                        form.eid.data, form.desc.data, visit.id, form.modality.data)
             place = queue_handler.enqueue(s)
             notifier.send_message(form.email.data,
                                   f"Notification from {app.config['COURSE_NAME']} Help Hours Queue",
                                   render_template("email/added_to_queue_email.html",
-                                                  view_link=app.config['WEBSITE_LINK'] + url_for('view'),
-                                                  place_str=routes_helper.get_place_str(place),
+                                                  view_link=app.config['WEBSITE_LINK'] + url_for(
+                                                      'view'),
+                                                  place_str=routes_helper.get_place_str(
+                                                      place),
                                                   student_name=form.name.data, remove_code=form.eid.data),
                                   'html')
             return redirect(url_for('view'))
@@ -76,7 +78,8 @@ def join():
             if len(form.errors) > 0:
                 message = next(iter(form.errors.values()))[0]
     # render the template for submitting otherwise
-    return render_template('join.html', form=form, queue_is_open=queue_is_open, message=message)
+    return render_template('join.html', form=form, dual_modality=app.config['DUAL_MODALITY'],
+                           queue_is_open=queue_is_open, message=message)
 
 
 @app.route("/view", methods=['GET', 'POST'])
@@ -107,7 +110,8 @@ def remove():
                 runner_up = queue_handler.peek_runner_up()
                 if runner_up is not None and not runner_up.notified:
                     try:
-                        log.debug(f"Sending runner up email to {runner_up.email}")
+                        log.debug(
+                            f"Sending runner up email to {runner_up.email}")
                         notifier.send_message(
                             runner_up.email, f'Notification from {app.config["COURSE_NAME"]} Help Hours Queue',
                             render_template(
@@ -117,7 +121,8 @@ def remove():
 
                         runner_up.notified = True
                     except Exception as e:
-                        log.warning(f"Failed to send email to {runner_up.email}. {e}")
+                        log.warning(
+                            f"Failed to send email to {runner_up.email}. {e}")
 
                 v = Visit.query.filter_by(id=s.id).first()
                 if v is not None:
@@ -127,7 +132,8 @@ def remove():
                     return redirect(url_for('view'))
                 else:
                     # Serious issue, there are inconsistencies in the database.
-                    log.error('Student in queue does not have a corresponding entry in visits table.', notify=True)
+                    log.error(
+                        'Student in queue does not have a corresponding entry in visits table.', notify=True)
                     return render_template('message_error.html', title="Error Removing from queue",
                                            body="Sorry, something went wrong when trying to remove you from the queue.")
             else:
@@ -165,7 +171,8 @@ def change_zoom():
 
             db.session.add(new_link)
             db.session.commit()
-            log.info(f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
+            log.info(
+                f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
 
             form = AddZoomLinkForm()
             form.url.data = ""
@@ -176,10 +183,12 @@ def change_zoom():
 
     elif remove_form.validate_on_submit() and remove_form.links.data is not None:
         if int(remove_form.links.data) != -1:
-            db.session.delete(ZoomLink.query.filter(ZoomLink.id == int(remove_form.links.data)).first())
+            db.session.delete(ZoomLink.query.filter(
+                ZoomLink.id == int(remove_form.links.data)).first())
             db.session.commit()
 
-            log.info(f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
+            log.info(
+                f'{current_user.first_name} {current_user.last_name} updated the Zoom links.')
             remove_message = "The zoom link has been removed!"
         else:
             remove_message = "Please select a link to remove"
@@ -236,7 +245,8 @@ def edit_instructor():
                 instr.is_active = 1 if form.is_active.data else 0
                 instr.is_admin = 1 if form.is_admin.data else 0
                 db.session.commit()
-                log.info(f'The account for {instr.first_name} {instr.last_name} was updated.')
+                log.info(
+                    f'The account for {instr.first_name} {instr.last_name} was updated.')
                 return redirect('admin_panel')
             else:
                 message = 'Enter a valid email address'
@@ -272,7 +282,8 @@ def add_instructor():
                 db.session.add(instr)
                 db.session.commit()
                 password_reset.new_user(instr)
-                log.info(f'New account created for {instr.first_name} {instr.last_name}.')
+                log.info(
+                    f'New account created for {instr.first_name} {instr.last_name}.')
                 return redirect('admin_panel')
             else:
                 message = 'Enter a valid email address'

--- a/helphours/routes.py
+++ b/helphours/routes.py
@@ -14,6 +14,9 @@ from werkzeug.security import generate_password_hash
 # Would likely need to be stored in a databse if we want multiple instances of this
 # running
 queue_is_open = False
+in_person_queue_is_open = None
+if app.config['DUAL_MODALITY']:
+    in_person_queue_is_open = True
 
 # Duck image to use during the day when the queue is open
 QUEUE_OPEN_DUCK = 'https://utcshelphours.com/duck.png'
@@ -30,6 +33,7 @@ CURRENT_DUCK = QUEUE_OPEN_DUCK
 def inject_variables():
     g.user = current_user
     g.queue_is_open = queue_is_open
+    g.in_person_queue_is_open = in_person_queue_is_open
 
 
 @app.context_processor
@@ -82,10 +86,14 @@ def join():
 @app.route("/view", methods=['GET', 'POST'])
 def view():
     global queue_is_open
+    global in_person_queue_is_open
     if request.method == "POST" and current_user.is_authenticated:
-        queue_is_open = routes_helper.handle_line_form(request, queue_is_open)
+        queue_is_open, in_person_queue_is_open = routes_helper.handle_line_form(request,
+                                                                                queue_is_open,
+                                                                                in_person_queue_is_open)
     queue = queue_handler.get_students()
-    return render_template('view.html', queue=queue, queue_is_open=queue_is_open)
+    return render_template('view.html', queue=queue, queue_is_open=queue_is_open,
+                           in_person_queue_is_open=in_person_queue_is_open)
 
 
 @app.route("/line", methods=['GET', 'POST'])

--- a/helphours/routes_helper.py
+++ b/helphours/routes_helper.py
@@ -4,7 +4,7 @@ from helphours.models.visit import Visit
 from datetime import datetime
 
 
-def handle_line_form(request, curr_open_state):
+def handle_line_form(request, curr_virtual_state, curr_in_person_state):
     """
         Handle post requests in the view line page.
         Will return a boolean indicating whether the line should be
@@ -13,13 +13,18 @@ def handle_line_form(request, curr_open_state):
     # Handle removing student, the line's "open state" should be unchanged.
     if 'finished' in request.form or 'removed' in request.form:
         handle_remove(request)
-        return curr_open_state
+        return curr_virtual_state, curr_in_person_state
     # Close the queue to new entries
-    elif 'close' in request.form:
-        return False
+    elif 'close-virtual' in request.form:
+        return False, curr_in_person_state
     # Open the queue to new entries
-    elif 'open' in request.form:
-        return True
+    elif 'open-virtual' in request.form:
+        return True, curr_in_person_state
+    elif 'close-in-person' in request.form:
+        return curr_virtual_state, False
+    elif 'open-in-person' in request.form:
+        return curr_virtual_state, True
+    return curr_virtual_state, curr_in_person_state
 
 
 def handle_remove(request):

--- a/helphours/static/scripts/join.js
+++ b/helphours/static/scripts/join.js
@@ -1,8 +1,14 @@
 // How often we check if the queue is open
-const UPDATE_INTERVAL_SECONDS = 10;
+const UPDATE_INTERVAL_SECONDS = 5;
 
 checkQueueIsOpen();
 setInterval(checkQueueIsOpen, UPDATE_INTERVAL_SECONDS * 1000);
+
+// Selectors for the <option>s in the modality dropdown
+const VIRTUAL_OPTION_SELECT = "#modality option[value='virtual']"
+const IN_PERSON_OPTION_SELECT = "#modality option[value='in_person']"
+
+const prettyStatus = (isOpen) => isOpen ? "(Open)" : "(Closed)"
 
 function checkQueueIsOpen() {
     fetch('/queue_status').then(response => response.json())
@@ -12,24 +18,34 @@ function checkQueueIsOpen() {
             // This means a join request may fail if the "wrong" queue
             // was open, but the backend handles this and an error
             // will be displayed.
-            if(data && (data.virtual_open || data.in_person_open))
-                queueIsOpen();
-            else
-                queueIsClosed(); 
+            if(data) {
+                console.log(data)
+                if(data.virtual_open || data.in_person_open) {
+                    someQueuesOpen();
+                }
+                // Displays status of each queue in the dropdown.
+                document.querySelector(VIRTUAL_OPTION_SELECT)
+                        .textContent = "Virtual " + prettyStatus(data.virtual_open);
+                document.querySelector(IN_PERSON_OPTION_SELECT)
+                        .textContent = "In-Person " + prettyStatus(data.in_person_open);
+            }
+            else {
+                bothQueuesClosed(); 
+            }
         })
-        .catch(queueIsClosed)
+        .catch(bothQueuesClosed)
 }
 
 // If the queue is closed we visually disable the submit button,
 // queue status is still checked on the back-end since this the
 // 'disabled' attribute can be removed
-function queueIsClosed() {
+function bothQueuesClosed() {
     const joinButton = document.getElementById('submit-button');
     joinButton.disabled = true;
     joinButton.title = 'The queue is closed.';
 }
 
-function queueIsOpen() {
+function someQueuesOpen() {
     const joinButton = document.getElementById('submit-button');
     joinButton.disabled = false;
     joinButton.removeAttribute('title');

--- a/helphours/static/scripts/join.js
+++ b/helphours/static/scripts/join.js
@@ -24,16 +24,21 @@ function checkQueueIsOpen() {
                     someQueuesOpen();
                 }
                 // Displays status of each queue in the dropdown.
-                document.querySelector(VIRTUAL_OPTION_SELECT)
-                        .textContent = "Virtual " + prettyStatus(data.virtual_open);
-                document.querySelector(IN_PERSON_OPTION_SELECT)
-                        .textContent = "In-Person " + prettyStatus(data.in_person_open);
+                const virtualOption = document.querySelector(VIRTUAL_OPTION_SELECT);
+                const inPersonOption = document.querySelector(IN_PERSON_OPTION_SELECT);
+                if(virtualOption)
+                    virtualOption.textContent = "Virtual " + prettyStatus(data.virtual_open);
+                if(inPersonOption)
+                    inPersonOption.textContent = "In-Person " + prettyStatus(data.in_person_open);
             }
             else {
                 bothQueuesClosed(); 
             }
         })
-        .catch(bothQueuesClosed)
+        .catch((e) => {
+            console.log(e);
+            bothQueuesClosed();
+        })
 }
 
 // If the queue is closed we visually disable the submit button,

--- a/helphours/static/scripts/join.js
+++ b/helphours/static/scripts/join.js
@@ -1,5 +1,5 @@
 // How often we check if the queue is open
-const UPDATE_INTERVAL_SECONDS = 5;
+const UPDATE_INTERVAL_SECONDS = 10;
 
 checkQueueIsOpen();
 setInterval(checkQueueIsOpen, UPDATE_INTERVAL_SECONDS * 1000);
@@ -7,7 +7,12 @@ setInterval(checkQueueIsOpen, UPDATE_INTERVAL_SECONDS * 1000);
 function checkQueueIsOpen() {
     fetch('/queue_status').then(response => response.json())
         .then((data) => {
-            if(data && data.status === "OPEN")
+            // Since we have two queues now, this gets a bit weirder.
+            // We'll leave the join button enabled if either queue is open.
+            // This means a join request may fail if the "wrong" queue
+            // was open, but the backend handles this and an error
+            // will be displayed.
+            if(data && (data.virtual_open || data.in_person_open))
                 queueIsOpen();
             else
                 queueIsClosed(); 

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -66,7 +66,14 @@ function renderQueue(data) {
     let queue = data.queue.filter(entry => viewStateMap[entry.modality]);
 
     if (!queue || queue.length === 0) {
-        displayMessage('The queue is empty.');
+        // We have no entries to display.
+        if(data.queue.length > 0) {
+            // Is it because the client filtered them away?
+            displayMessage('No entries for specified queue(s).')
+        } else {
+            // Or is there actually no one in line
+            displayMessage('The queue is empty.');
+        }
     } else {
         let queueContainer = document.getElementById("queue");
         let template = document.getElementById("queue-entry-template");

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -78,6 +78,17 @@ function renderQueue(data) {
             // Add this person's place in line and name
             newEntry.querySelector('.queue-entry-position').textContent = queue[i].position + ":";
             newEntry.querySelector('.queue-entry-name').textContent = queue[i].name;
+           
+            // Display modality for entry
+            const modalities = {
+                'remote': "Remote",
+                'in_person': "In Person"
+            };
+            const modalityDisplay = modalities[queue[i].modality];
+            if(modalityDisplay)
+                newEntry.querySelector('.queue-entry-modality').textContent = `(${modalityDisplay})`;
+            else
+                newEntry.querySelector('.queue-entry-modality').style.display = 'none';
 
             if ("id" in queue[i]) {
                 // If the id of the student is present, then we are authenticated as an

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -19,13 +19,13 @@ var updateInterval = setInterval(updateQueue, UPDATE_INTERVAL_SECONDS * 1000);
 const store1 = window.localStorage;
 var viewStateMap = new Map();
 
-viewStateMap['remote'] = store1.getItem('remote') == null ? true : store1.getItem('remote') == 'true';
+viewStateMap['virtual'] = store1.getItem('virtual') == null ? true : store1.getItem('virtual') == 'true';
 viewStateMap['in_person'] = store1.getItem('in_person') == null ? true : store1.getItem('in_person') == 'true';
 
-document.getElementById("virtual-queue").checked = viewStateMap['remote'];
+document.getElementById("virtual-queue").checked = viewStateMap['virtual'];
 document.getElementById("in-person-queue").checked = viewStateMap['in_person'];
 
-store1.setItem('remote', viewStateMap['remote']);
+store1.setItem('virtual', viewStateMap['virtual']);
 store1.setItem('in_person', viewStateMap['in_person']);
 
 var checkboxesChanged = false;
@@ -88,8 +88,8 @@ function renderQueue(data) {
 
             // Display modality for entry
             const modalities = {
-                'remote': "Remote",
-                'in_person': "In Person"
+                'virtual': "Virtual",
+                'in_person': "In-Person"
             };
             const modalityDisplay = modalities[queue[i].modality];
             if (modalityDisplay)

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -16,6 +16,20 @@ updateQueue();
 
 var updateInterval = setInterval(updateQueue, UPDATE_INTERVAL_SECONDS * 1000);
 
+const store1 = window.localStorage;
+var viewStateMap = new Map();
+
+viewStateMap['remote'] = store1.getItem('remote') == null ? true : store1.getItem('remote') == 'true';
+viewStateMap['in_person'] = store1.getItem('in_person') == null ? true : store1.getItem('in_person') == 'true';
+
+document.getElementById("virtual-queue").checked = viewStateMap['remote'];
+document.getElementById("in-person-queue").checked = viewStateMap['in_person'];
+
+store1.setItem('remote', viewStateMap['remote']);
+store1.setItem('in_person', viewStateMap['in_person']);
+
+var checkboxesChanged = false;
+
 // After TIMEOUT_MINUTES, stop retrieving the queue; the client is probably
 // idle or left the page open accidentally
 setTimeout(() => {
@@ -40,7 +54,7 @@ function updateQueue() {
 // update the page if necessary.
 function renderQueue(data) {
     let dataJSON = JSON.stringify(data);
-    if(lastPullResponse === dataJSON){
+    if (lastPullResponse === dataJSON && !checkboxesChanged) {
         // Nothing changed, don't bother re-rendering
         return;
     }
@@ -49,12 +63,11 @@ function renderQueue(data) {
     clearQueue();
     lastPullResponse = dataJSON;
 
-    let queue = data.queue;
+    let queue = data.queue.filter(entry => viewStateMap[entry.modality]);
 
     if (!queue || queue.length === 0) {
         displayMessage('The queue is empty.');
-    }
-    else {
+    } else {
         let queueContainer = document.getElementById("queue");
         let template = document.getElementById("queue-entry-template");
         let newDropDownStates = {};
@@ -66,14 +79,14 @@ function renderQueue(data) {
             newEntry.querySelector('.queue-entry-position').textContent = queue[i].position + ":";
             newEntry.querySelector('.queue-entry-name').textContent = queue[i].name;
 
-            if("id" in queue[i]){
+            if ("id" in queue[i]) {
                 // If the id of the student is present, then we are authenticated as an
                 // instructor, so prepare all other instructor-only fields
                 newEntry.querySelector('.queue-entry-expanded-desc').textContent = queue[i].desc;
                 newEntry.querySelector('.queue-entry-expanded-time').textContent = queue[i].time;
                 // Assing this entry's id so we know who was helped/removed
-                newEntry.querySelectorAll('button').forEach(button => 
-                    button.value=queue[i].id
+                newEntry.querySelectorAll('button').forEach(button =>
+                    button.value = queue[i].id
                 );
                 // Retrieve the DOM nodes from the fragment
                 let entry = Array.prototype.slice.call(newEntry.childNodes)[1];
@@ -84,7 +97,7 @@ function renderQueue(data) {
                 expandToggle.style.cursor = 'pointer';
 
                 // Restore previous dropdown states
-                if(queue[i].id in dropDownStates && dropDownStates[queue[i].id]){
+                if (queue[i].id in dropDownStates && dropDownStates[queue[i].id]) {
                     entry.querySelector('.queue-entry-box').classList.toggle('active');
                     entry.querySelector('.queue-entry-expanded').classList.toggle('active');
                     newDropDownStates[queue[i].id] = true;
@@ -105,13 +118,15 @@ function renderQueue(data) {
         }
         dropDownStates = newDropDownStates;
     }
+
+    checkboxesChanged = false;
 }
 
 // Gets rid of all entries in the queue div
 function clearQueue() {
-   let queue = document.getElementById("queue");
-   if(queue)
-        while(queue.firstChild)
+    let queue = document.getElementById("queue");
+    if (queue)
+        while (queue.firstChild)
             queue.removeChild(queue.firstChild)
 }
 
@@ -123,9 +138,16 @@ function displayMessage(content) {
     document.getElementById('queue').appendChild(message);
 }
 
- // Function which will toggle whether the entry accordion is open
- function toggleExpanded(queueEntry, entryId) {
+// Function which will toggle whether the entry accordion is open
+function toggleExpanded(queueEntry, entryId) {
     queueEntry.querySelector('.queue-entry-box').classList.toggle('active');
     queueEntry.querySelector('.queue-entry-expanded').classList.toggle('active');
     dropDownStates[entryId] = !dropDownStates[entryId];
+}
+
+function setCheckbox(queue) {
+    viewStateMap[queue] = !viewStateMap[queue];
+    store1.setItem(queue, viewStateMap[queue]);
+    checkboxesChanged = true;
+    updateQueue();
 }

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -92,10 +92,10 @@ function renderQueue(data) {
                 'in_person': "In-Person"
             };
             const modalityDisplay = modalities[queue[i].modality];
-            if (modalityDisplay)
-                newEntry.querySelector('.queue-entry-modality').textContent = `(${modalityDisplay})`;
-            else
-                newEntry.querySelector('.queue-entry-modality').style.display = 'none';
+            const modalityLabel = newEntry.querySelector('.queue-entry-modality');
+            // only show label if modality value is well-formed and modality label div is in the HTML
+            if (modalityDisplay && modalityLabel)
+                modalityLabel.textContent = `(${modalityDisplay})`;
 
             if ("id" in queue[i]) {
                 // If the id of the student is present, then we are authenticated as an

--- a/helphours/static/scripts/queue.js
+++ b/helphours/static/scripts/queue.js
@@ -19,8 +19,8 @@ var updateInterval = setInterval(updateQueue, UPDATE_INTERVAL_SECONDS * 1000);
 const store1 = window.localStorage;
 var viewStateMap = new Map();
 
-viewStateMap['remote'] = store1.getItem('remote') == null ? true : store1.getItem('remote') == 'true';
-viewStateMap['in_person'] = store1.getItem('in_person') == null ? true : store1.getItem('in_person') == 'true';
+viewStateMap['remote'] = store1.getItem('remote') == null ? true : store1.getItem('remote');
+viewStateMap['in_person'] = store1.getItem('in_person') == null ? true : store1.getItem('in_person'); 
 
 document.getElementById("virtual-queue").checked = viewStateMap['remote'];
 document.getElementById("in-person-queue").checked = viewStateMap['in_person'];

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -554,6 +554,8 @@ textarea {
     -webkit-box-pack: center;
         -ms-flex-pack: center;
             justify-content: center;
+    flex-direction: column;
+    align-items: center;
     padding: 20px 0px;
 }
 

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -1,9 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap');
-
 :root {
-    --primary-color: #0080ff; 
+    --primary-color: #0080ff;
     --light-primary-color: #a1d0ff;
-
     /* Light blue -> Light Green */
     /* Backup navbar variables, these will be overriden in base.html */
     --navbar-gradient: linear-gradient(80deg, #7ee8fd 0%, #80ff72 110%);
@@ -21,7 +19,6 @@
 .dark a {
     color: inherit;
 }
-
 
 .dark .reset-link {
     color: cyan;
@@ -56,7 +53,7 @@ body h3 {
 .navbar {
     background-image: var(--navbar-gradient);
     -webkit-box-shadow: -2px 0 2px 2px rgba(0, 0, 0, 0.1);
-            box-shadow: -2px 0 2px 2px rgba(0, 0, 0, 0.1);
+    box-shadow: -2px 0 2px 2px rgba(0, 0, 0, 0.1);
     max-height: 10vh;
     display: -webkit-box;
     display: -ms-flexbox;
@@ -67,7 +64,7 @@ body h3 {
 
 .dark .navbar {
     -webkit-box-shadow: -2px 0 16px 2px var(--navbar-background);
-            box-shadow: -2px 0 16px 2px var(--navbar-background);
+    box-shadow: -2px 0 16px 2px var(--navbar-background);
 }
 
 .navbar ul {
@@ -75,8 +72,8 @@ body h3 {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
     list-style: none;
 }
 
@@ -113,15 +110,20 @@ body h3 {
     transition: font-size 0.2s ease;
 }
 
-.navbar a:hover:not(.no-grow), .navbar a:focus:not(.no-grow) {
+.navbar a:hover:not(.no-grow),
+.navbar a:focus:not(.no-grow) {
     font-size: 120%;
 }
 
-.link:visited, .link:active, .link:hover {
+.link:visited,
+.link:active,
+.link:hover {
     color: #000;
 }
 
-.dark .link:visited, .dark .link:active, .dark .link:hover {
+.dark .link:visited,
+.dark .link:active,
+.dark .link:hover {
     color: #fff;
 }
 
@@ -130,11 +132,11 @@ body h3 {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
     -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
 }
 
 .narrow-content {
@@ -143,8 +145,8 @@ body h3 {
 
 .duck-left {
     -webkit-transform: scaleX(-1);
-            -ms-transform: scaleX(-1);
-        transform: scaleX(-1);
+    -ms-transform: scaleX(-1);
+    transform: scaleX(-1);
 }
 
 .vertical-center {
@@ -152,20 +154,18 @@ body h3 {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
 }
 
 .vertical-center h1 {
     margin: 0 20px;
 }
 
-
 .content {
     height: 100%;
     max-height: 90vh;
     padding: 10px 10px;
-
     width: 90%;
     max-width: 1200px;
     margin-left: auto;
@@ -177,10 +177,10 @@ body h3 {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-line-pack: center;
-        align-content: center;
+    align-content: center;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
     width: 100%;
     height: 100%;
 }
@@ -190,10 +190,10 @@ body h3 {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-line-pack: center;
-        align-content: center;
+    align-content: center;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
 }
 
 .dropdown {
@@ -231,33 +231,29 @@ body h3 {
     background-color: #eee;
     min-width: 30%;
     -webkit-box-shadow: 5px 5px 10px #ccc;
-            box-shadow: 5px 5px 10px #ccc;
+    box-shadow: 5px 5px 10px #ccc;
     -ms-flex-item-align: center;
-        align-self: center;
+    align-self: center;
     padding: 20px;
     border-radius: 5px;
-
     display: -webkit-box;
-
     display: -ms-flexbox;
-
     display: flex;
     -ms-flex-line-pack: center;
-        align-content: center;
+    align-content: center;
     -webkit-box-pack: Zoom;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column; 
+    -ms-flex-direction: column;
+    flex-direction: column;
 }
 
-
-.dark .form-container{
+.dark .form-container {
     background-color: inherit;
     -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     border: 1px solid white
 }
 
@@ -289,7 +285,8 @@ body h3 {
     cursor: pointer;
 }
 
-.form-submit:disabled, .form-submit[disabled] {
+.form-submit:disabled,
+.form-submit[disabled] {
     background-color: var(--light-primary-color);
     cursor: not-allowed;
 }
@@ -312,7 +309,7 @@ body h3 {
     border: 1px solid rgba(0, 0, 0, 0.1);
     padding: 10px;
     -webkit-box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.1);
-            box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.1);
     margin: 5px 0px;
     width: 100%;
 }
@@ -328,21 +325,22 @@ body h3 {
     min-width: 50%;
 }
 
-.form > div {
+.form>div {
     width: 100%;
     padding: 10px 0;
 }
 
 textarea {
- margin: 10px 0px;   
- width: 100%;
+    margin: 10px 0px;
+    width: 100%;
 }
 
 .error-message {
     color: red;
 }
 
-.helped-button, .queue-open-button {
+.helped-button,
+.queue-open-button {
     padding: 12px;
     background-color: #4c8;
     color: #fff;
@@ -352,7 +350,8 @@ textarea {
     margin: 5 5 0 0;
 }
 
-.remove-button, .queue-close-button {
+.remove-button,
+.queue-close-button {
     padding: 12px;
     background-color: #ed2939;
     color: #fff;
@@ -362,8 +361,10 @@ textarea {
     margin: 5 5 0 0;
 }
 
-.remove-button:disabled, .remove-button[disabled],
-.queue-close-button:disabled, .queue-close-button[disabled] {
+.remove-button:disabled,
+.remove-button[disabled],
+.queue-close-button:disabled,
+.queue-close-button[disabled] {
     background-color: #e9959c;
     cursor: not-allowed;
 }
@@ -373,17 +374,17 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
     -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
 }
 
 .reset-link {
     -ms-flex-item-align: center;
-        -ms-grid-row-align: center;
-        align-self: center;
+    -ms-grid-row-align: center;
+    align-self: center;
 }
 
 .form-group {
@@ -400,7 +401,6 @@ textarea {
     width: 100%;
 }
 
-
 .queue-container {
     width: 75%;
     height: 100%;
@@ -414,12 +414,11 @@ textarea {
     }
 }
 
-
 .queue-entry {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
-    align-items: center; 
+    align-items: center;
     margin-bottom: 20px;
     flex-wrap: wrap;
     justify-content: space-evenly;
@@ -428,7 +427,7 @@ textarea {
 .queue-entry-box {
     padding: 12px;
     -webkit-box-shadow: 5px 5px 10px #ccc;
-            box-shadow: 5px 5px 10px #ccc;
+    box-shadow: 5px 5px 10px #ccc;
     border-radius: 5px;
     background-color: #eee;
     /* width: 80%; */
@@ -447,7 +446,7 @@ textarea {
 
 .dark .queue-entry-box {
     -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     border: 1px solid white;
     background-color: inherit;
 }
@@ -463,14 +462,14 @@ textarea {
 }
 
 .queue-entry-expanded {
-   /* width: 100%;  */
-   background-color: #ddd;
-   border-radius: 0px 0px 5px 5px;
-   padding: 15px;
+    /* width: 100%;  */
+    background-color: #ddd;
+    border-radius: 0px 0px 5px 5px;
+    padding: 15px;
     -webkit-box-shadow: 5px 5px 10px #ccc;
-            box-shadow: 5px 5px 10px #ccc;
-   margin-top: -2px;
-   display: none;
+    box-shadow: 5px 5px 10px #ccc;
+    margin-top: -2px;
+    display: none;
 }
 
 .dark .queue-entry-expanded {
@@ -491,15 +490,15 @@ textarea {
     transition: transform 0.1s ease-in;
 }
 
-.queue-entry-box.active .queue-chevron{
+.queue-entry-box.active .queue-chevron {
     transform: rotate(360deg);
 }
 
 .queue-entry-left {
     float: left;
     -ms-flex-item-align: center;
-        -ms-grid-row-align: center;
-        align-self: center;
+    -ms-grid-row-align: center;
+    align-self: center;
 }
 
 .queue-entry-desc {
@@ -513,8 +512,8 @@ textarea {
 .queue-entry-right {
     margin-left: auto;
     -ms-flex-item-align: center;
-        -ms-grid-row-align: center;
-        align-self: center;
+    -ms-grid-row-align: center;
+    align-self: center;
     white-space: nowrap;
 }
 
@@ -546,14 +545,18 @@ textarea {
     color: #222;
 }
 
+.dark .queue-entry-modality {
+    color: #ccc;
+}
+
 .queue-controls {
     width: 100%;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
     flex-direction: column;
     align-items: center;
     padding: 20px 0px;
@@ -586,8 +589,8 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
 }
 
 .stats-nav {
@@ -629,7 +632,7 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-pack: distribute;
-        justify-content: space-around;
+    justify-content: space-around;
     width: 100%;
 }
 
@@ -639,13 +642,13 @@ textarea {
     display: flex;
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
     -ms-flex-line-pack: center;
-        align-content: center;
+    align-content: center;
     -webkit-box-pack: center;
-        -ms-flex-pack: center;
-            justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
     text-align: center;
 }
 
@@ -660,11 +663,11 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-pack: distribute;
-        justify-content: space-around;
+    justify-content: space-around;
     flex-wrap: wrap;
 }
 
-.dark .graph  text{
+.dark .graph text {
     fill: #fff !important;
 }
 
@@ -672,9 +675,11 @@ textarea {
     fill: #444 !important;
 }
 
-.dark .graph path, .dark .graph line {
+.dark .graph path,
+.dark .graph line {
     stroke: #fff !important;
 }
+
 
 /* Tables */
 
@@ -714,8 +719,8 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-between;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
 }
 
 .dark-mode-button {
@@ -754,24 +759,31 @@ textarea {
     color: #000;
 }
 
-.no-transition, .no-transition * {
+.no-transition,
+.no-transition * {
     -webkit-transition: none !important;
     -o-transition: none !important;
     transition: none !important;
 }
 
-.meeting-link, .meeting-link:link, .meeting-link:active, .meeting-link:visited, .meeting-link:hover {
+.meeting-link,
+.meeting-link:link,
+.meeting-link:active,
+.meeting-link:visited,
+.meeting-link:hover {
     text-decoration: none;
     color: inherit;
     font-weight: bold;
     font-size: 120%;
 }
 
-.meeting-link:hover, .meeting-link:focus {
+.meeting-link:hover,
+.meeting-link:focus {
     color: var(--primary-color);
 }
 
-.dark .meeting-link:hover, .dark .meeting-link:focus {
+.dark .meeting-link:hover,
+.dark .meeting-link:focus {
     color: inherit;
     border-color: var(--navbar-background);
 }
@@ -789,7 +801,7 @@ textarea {
     display: -ms-flexbox;
     display: flex;
     padding: 20px 30px;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.15), 0 6px 6px rgba(0,0,0,0.20);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15), 0 6px 6px rgba(0, 0, 0, 0.20);
     border-radius: 5px;
     background-color: #eee;
     margin-bottom: 20px;
@@ -797,18 +809,20 @@ textarea {
     margin-bottom: 30px;
 }
 
-.meeting-link:hover, .meeting-link:focus {
-    box-shadow: 0 14px 28px rgba(0,0,0,0.20), 0 10px 10px rgba(0,0,0,0.17);
+.meeting-link:hover,
+.meeting-link:focus {
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.20), 0 10px 10px rgba(0, 0, 0, 0.17);
 }
 
 .dark .meeting-link {
     -webkit-box-shadow: none;
-            box-shadow: none;
+    box-shadow: none;
     border: 1px solid white;
     background-color: inherit;
 }
 
-.dark .meeting-link:hover, .dark .meeting-link:focus {
+.dark .meeting-link:hover,
+.dark .meeting-link:focus {
     transform: translateY(-3px);
 }
 

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -541,6 +541,11 @@ textarea {
     /* margin-left: 20px; */
 }
 
+.queue-entry-modality {
+    display: inline-block;
+    color: #222;
+}
+
 .queue-controls {
     width: 100%;
     display: -webkit-box;

--- a/helphours/static/styles/style.css
+++ b/helphours/static/styles/style.css
@@ -349,6 +349,7 @@ textarea {
     border-radius: 5px;
     border: none;
     cursor: pointer;
+    margin: 5 5 0 0;
 }
 
 .remove-button, .queue-close-button {
@@ -358,6 +359,7 @@ textarea {
     border-radius: 5px;
     border: none;
     cursor: pointer;
+    margin: 5 5 0 0;
 }
 
 .remove-button:disabled, .remove-button[disabled],

--- a/helphours/student.py
+++ b/helphours/student.py
@@ -3,14 +3,14 @@ from datetime import datetime
 
 class Student:
 
-    REMOTE = 'remote'
+    VIRTUAL = 'virtual'
     IN_PERSON = 'in_person'
 
     """
         Class to represent a Student entry in the
         Lab Hours Queue.
     """
-    def __init__(self, name, email, eid, desc, uid, modality=REMOTE):
+    def __init__(self, name, email, eid, desc, uid, modality=VIRTUAL):
         self.name = name
         self.email = email
         self.eid = eid

--- a/helphours/student.py
+++ b/helphours/student.py
@@ -2,11 +2,15 @@ from datetime import datetime
 
 
 class Student:
+
+    REMOTE = 'remote'
+    IN_PERSON = 'in_person'
+
     """
         Class to represent a Student entry in the
         Lab Hours Queue.
     """
-    def __init__(self, name, email, eid, desc, uid):
+    def __init__(self, name, email, eid, desc, uid, modality):
         self.name = name
         self.email = email
         self.eid = eid
@@ -20,17 +24,21 @@ class Student:
         self.id = str(uid)
         self.time_entered = datetime.now().strftime('%H:%M:%S')
 
+        # Whether or not the student is in-person or virtual
+        self.modality = modality
+
     def serialize_student_view(self, position):
         return {
             'name': self.name,
             'position': position,
-            # 'id': self.id
+            'modality': self.modality
         }
 
     def serialize_instructor_view(self, position):
         return {
             'name': self.name,
             'position': position,
+            'modality': self.modality,
             'desc': self.desc,
             'id': self.id,
             'time': self.time_entered,

--- a/helphours/student.py
+++ b/helphours/student.py
@@ -10,7 +10,7 @@ class Student:
         Class to represent a Student entry in the
         Lab Hours Queue.
     """
-    def __init__(self, name, email, eid, desc, uid, modality):
+    def __init__(self, name, email, eid, desc, uid, modality=REMOTE):
         self.name = name
         self.email = email
         self.eid = eid

--- a/helphours/templates/join.html
+++ b/helphours/templates/join.html
@@ -31,6 +31,13 @@
                 {{ form.desc(class="form-input", autocomplete="off") }}
             </div>
 
+            {% if dual_modality %}
+            <div>
+                {{ form.modality.label(class="form-label") }}
+                {{ form.modality(class="form-input") }}
+            </div>
+            {% endif %}
+
             {% if message|length > 0 %}
                 <p class="error-message">{{ message }}</p>
             {% endif %}

--- a/helphours/templates/view.html
+++ b/helphours/templates/view.html
@@ -12,20 +12,30 @@
 
 
 <div class="queue-container">
-        <div class="queue-controls">
-            <form method="POST">
-                {% if g.user.is_authenticated %}
-                    {% if queue_is_open %}
-                        <button name="close" class="queue-close-button">Close Queue</button>
-                    {% else %}
-                        <button name="open" class="queue-open-button">Open Queue</button>
-                    {% endif %}
-                {% endif %}
-            </form>
+    <div class="queue-controls">
+        {% if g.user.is_authenticated %}
+        <form method="POST">
+            <div style="display: flex;">
+                {% if queue_is_open %}
+                <button name="close-virtual" class="queue-close-button">Close Virtual Queue</button> {% else %}
+                <button name="open-virtual" class="queue-open-button">Open Virtual Queue</button> {% endif %} {% if in_person_queue_is_open == True %}
+                <button name="close-in-person" class="queue-close-button">Close In Person Queue</button> {% elif in_person_queue_is_open == False %}
+                <button name="open-in-person" class="queue-open-button">Open In Person Queue</button> {% endif %}
+            </div>
+        </form>
+        {% endif %} {% if in_person_queue_is_open != None %}
+        <div>
+            <input type="checkbox" checked id="virtual-queue" name="virtual-queue" value="virtual" onclick="setCheckbox('remote');">
+            <label for="virtual-queue"> Virtual Help Hours Queue</label><br></div>
+        <div>
+            <input type="checkbox" checked id="in-person-queue" name="in-person-queue" value="in-person" onclick="setCheckbox('in_person');">
+            <label for="in-person-queue"> In Person Help Hours Queue</label><br>
         </div>
+        {% endif %}
+    </div>
 
-   <div id="queue">
-   </div> 
+    <div id="queue">
+    </div> 
 
     <script src="{{ url_for('static', filename='scripts/queue.js') }}"></script>
 </div>

--- a/helphours/templates/view.html
+++ b/helphours/templates/view.html
@@ -19,17 +19,17 @@
                 {% if queue_is_open %}
                 <button name="close-virtual" class="queue-close-button">Close Virtual Queue</button> {% else %}
                 <button name="open-virtual" class="queue-open-button">Open Virtual Queue</button> {% endif %} {% if in_person_queue_is_open == True %}
-                <button name="close-in-person" class="queue-close-button">Close In Person Queue</button> {% elif in_person_queue_is_open == False %}
-                <button name="open-in-person" class="queue-open-button">Open In Person Queue</button> {% endif %}
+                <button name="close-in-person" class="queue-close-button">Close In-Person Queue</button> {% elif in_person_queue_is_open == False %}
+                <button name="open-in-person" class="queue-open-button">Open In-Person Queue</button> {% endif %}
             </div>
         </form>
         {% endif %} {% if in_person_queue_is_open != None %}
         <div>
-            <input type="checkbox" checked id="virtual-queue" name="virtual-queue" value="virtual" onclick="setCheckbox('remote');">
-            <label for="virtual-queue"> Virtual Help Hours Queue</label><br></div>
+            <input type="checkbox" checked id="virtual-queue" name="virtual-queue" value="virtual" onclick="setCheckbox('virtual');">
+            <label for="virtual-queue"> Show Virtual Queue</label><br></div>
         <div>
             <input type="checkbox" checked id="in-person-queue" name="in-person-queue" value="in-person" onclick="setCheckbox('in_person');">
-            <label for="in-person-queue"> In Person Help Hours Queue</label><br>
+            <label for="in-person-queue"> Show In-Person Queue</label><br>
         </div>
         {% endif %}
     </div>

--- a/helphours/templates/view.html
+++ b/helphours/templates/view.html
@@ -49,6 +49,7 @@
                 <div class="queue-entry-expand-toggle">
                     <svg class="queue-chevron" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid meet" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="#626262"/><rect x="0" y="0" width="1200" height="1200" fill="rgba(0, 0, 0, 0)" /></svg>
                     <div class="queue-entry-name"></div>
+                    <div class="queue-entry-modality"></div>
                 </div>
                 <div class="queue-entry-right">
                     <form method="POST" class="queue-entry-buttons">

--- a/helphours/templates/view.html
+++ b/helphours/templates/view.html
@@ -14,23 +14,31 @@
 <div class="queue-container">
     <div class="queue-controls">
         {% if g.user.is_authenticated %}
-        <form method="POST">
-            <div style="display: flex;">
-                {% if queue_is_open %}
-                <button name="close-virtual" class="queue-close-button">Close Virtual Queue</button> {% else %}
-                <button name="open-virtual" class="queue-open-button">Open Virtual Queue</button> {% endif %} {% if in_person_queue_is_open == True %}
-                <button name="close-in-person" class="queue-close-button">Close In-Person Queue</button> {% elif in_person_queue_is_open == False %}
-                <button name="open-in-person" class="queue-open-button">Open In-Person Queue</button> {% endif %}
+            <form method="POST">
+                <div style="display: flex;">
+                    {% if queue_is_open %}
+                        <button name="close-virtual" class="queue-close-button">Close Virtual Queue</button>
+                    {% else %}
+                        <button name="open-virtual" class="queue-open-button">Open Virtual Queue</button> 
+                    {% endif %}
+
+                    {% if in_person_queue_is_open == True %}
+                        <button name="close-in-person" class="queue-close-button">Close In-Person Queue</button>
+                    {% elif in_person_queue_is_open == False %}
+                        <button name="open-in-person" class="queue-open-button">Open In-Person Queue</button>
+                    {% endif %}
+                </div>
+            </form>
+        {% endif %} 
+
+        {% if in_person_queue_is_open != None %}
+            <div>
+                <input type="checkbox" checked id="virtual-queue" name="virtual-queue" value="virtual" onclick="setCheckbox('virtual');">
+                <label for="virtual-queue"> Show Virtual Queue</label><br></div>
+            <div>
+                <input type="checkbox" checked id="in-person-queue" name="in-person-queue" value="in-person" onclick="setCheckbox('in_person');">
+                <label for="in-person-queue"> Show In-Person Queue</label><br>
             </div>
-        </form>
-        {% endif %} {% if in_person_queue_is_open != None %}
-        <div>
-            <input type="checkbox" checked id="virtual-queue" name="virtual-queue" value="virtual" onclick="setCheckbox('virtual');">
-            <label for="virtual-queue"> Show Virtual Queue</label><br></div>
-        <div>
-            <input type="checkbox" checked id="in-person-queue" name="in-person-queue" value="in-person" onclick="setCheckbox('in_person');">
-            <label for="in-person-queue"> Show In-Person Queue</label><br>
-        </div>
         {% endif %}
     </div>
 
@@ -49,7 +57,9 @@
                 <div class="queue-entry-expand-toggle">
                     <svg class="queue-chevron" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" preserveAspectRatio="xMidYMid meet" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="#626262"/><rect x="0" y="0" width="1200" height="1200" fill="rgba(0, 0, 0, 0)" /></svg>
                     <div class="queue-entry-name"></div>
-                    <div class="queue-entry-modality"></div>
+                    {% if in_person_queue_is_open != None %}
+                        <div class="queue-entry-modality"></div>
+                    {% endif %}
                 </div>
                 <div class="queue-entry-right">
                     <form method="POST" class="queue-entry-buttons">


### PR DESCRIPTION
## Description

This adds a config option, `DUAL_MODALITY`, which changes the following when set. (If not set, the website is mostly unchanged.)

### Join Page

When students join the queue, they'll need to choose either "Virtual" or "In Person" from a drop down menu. The entries in the dropdown menu will dynamically reflect if the queues are open or closed.

## View Page

Everyone can see each student's modality preference next to their name. Everyone can also filter the view queue page by modality (e.g. only look at "in-person" entries).

Instructors can open/close the "virtual" and "in-person" queues independently.

